### PR TITLE
chore: use setup-node dependency caching

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -11,11 +11,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14
-      - uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-yarn-
+          cache: yarn
       - run: yarn install --check-files --frozen-lockfile --non-interactive
       - id: format
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,12 +12,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: yarn
       - uses: reviewdog/action-setup@v1
-      - uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-yarn-
       - run: yarn install --check-files --frozen-lockfile --non-interactive
       - run: yarn --silent lint:rdjson | reviewdog -f=rdjson -reporter=github-pr-review
         env:


### PR DESCRIPTION
See: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/