### PR TITLE
chore: ignore CHANGELOG.md from formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
+CHANGELOG.md
 dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,26 @@
 # [1.1.0](https://github.com/tuqulore/website-boilerplate/compare/v1.0.0...v1.1.0) (2022-03-15)
 
+
 ### Bug Fixes
 
-- **deps:** pin dependency serve-handler to 6.1.3 ([c18e7ef](https://github.com/tuqulore/website-boilerplate/commit/c18e7ef177edfcae1b64404d519182f637150f4f))
-- file extensions not enough for formatting ([2e3f3b8](https://github.com/tuqulore/website-boilerplate/commit/2e3f3b87e14a7eb1c0b209f74aa1c4352c928f87))
-- **github workflows:** job name ([1ef2495](https://github.com/tuqulore/website-boilerplate/commit/1ef249517d2f135d0924dffeaec10e81122fd804))
-- invalid gloud sub command ([15653ec](https://github.com/tuqulore/website-boilerplate/commit/15653ece18f67e2a847cb5cc768a9249b723a8d8))
-- invalid workflow file ([8af1e3e](https://github.com/tuqulore/website-boilerplate/commit/8af1e3eff49f4a5f38f0c3ffe34b28d44980cb59))
-- invalid workflow file ([7d626e6](https://github.com/tuqulore/website-boilerplate/commit/7d626e658f145630507b66dce0cb7aa197c20ee6))
-- prettier拡張子がscssのままで変換対象が漏れている ([16af980](https://github.com/tuqulore/website-boilerplate/commit/16af980e5ead00d3b621ed58035fbedbe73931e7))
-- remain before cache busting target files ([92d2142](https://github.com/tuqulore/website-boilerplate/commit/92d21424c37a13d838169e0b41aa09a4b395d327))
-- setTemplateFormats recognizes js as template unexpectedly ([7312a7b](https://github.com/tuqulore/website-boilerplate/commit/7312a7b00a0d4c1b75c4c5a74d5d89fa0e9c9c59))
-- unexpected file input to postcss-cli ([d078e1f](https://github.com/tuqulore/website-boilerplate/commit/d078e1fc9c9d8e2dd9e3c81381ebe11981f8c475))
-- スタイル変更がyarn:dev時にlive reloadされない ([9277548](https://github.com/tuqulore/website-boilerplate/commit/927754896fd1315afee818bd33571e28f90bddc0))
-- ビルド時最適化した画像に対してFile not Foundとなる ([71fad28](https://github.com/tuqulore/website-boilerplate/commit/71fad285d3f2c8c097aaa91ea832df2dcb15c814))
-- 任意の拡張子のcssファイルの拡張子がcssにならない ([04e3dba](https://github.com/tuqulore/website-boilerplate/commit/04e3dbad99207f4b20829e93894daf0a4a191ea0))
+* **deps:** pin dependency serve-handler to 6.1.3 ([c18e7ef](https://github.com/tuqulore/website-boilerplate/commit/c18e7ef177edfcae1b64404d519182f637150f4f))
+* file extensions not enough for formatting ([2e3f3b8](https://github.com/tuqulore/website-boilerplate/commit/2e3f3b87e14a7eb1c0b209f74aa1c4352c928f87))
+* **github workflows:** job name ([1ef2495](https://github.com/tuqulore/website-boilerplate/commit/1ef249517d2f135d0924dffeaec10e81122fd804))
+* invalid gloud sub command ([15653ec](https://github.com/tuqulore/website-boilerplate/commit/15653ece18f67e2a847cb5cc768a9249b723a8d8))
+* invalid workflow file ([8af1e3e](https://github.com/tuqulore/website-boilerplate/commit/8af1e3eff49f4a5f38f0c3ffe34b28d44980cb59))
+* invalid workflow file ([7d626e6](https://github.com/tuqulore/website-boilerplate/commit/7d626e658f145630507b66dce0cb7aa197c20ee6))
+* prettier拡張子がscssのままで変換対象が漏れている ([16af980](https://github.com/tuqulore/website-boilerplate/commit/16af980e5ead00d3b621ed58035fbedbe73931e7))
+* remain before cache busting target files ([92d2142](https://github.com/tuqulore/website-boilerplate/commit/92d21424c37a13d838169e0b41aa09a4b395d327))
+* setTemplateFormats recognizes js as template unexpectedly ([7312a7b](https://github.com/tuqulore/website-boilerplate/commit/7312a7b00a0d4c1b75c4c5a74d5d89fa0e9c9c59))
+* unexpected file input to postcss-cli ([d078e1f](https://github.com/tuqulore/website-boilerplate/commit/d078e1fc9c9d8e2dd9e3c81381ebe11981f8c475))
+* スタイル変更がyarn:dev時にlive reloadされない ([9277548](https://github.com/tuqulore/website-boilerplate/commit/927754896fd1315afee818bd33571e28f90bddc0))
+* ビルド時最適化した画像に対してFile not Foundとなる ([71fad28](https://github.com/tuqulore/website-boilerplate/commit/71fad285d3f2c8c097aaa91ea832df2dcb15c814))
+* 任意の拡張子のcssファイルの拡張子がcssにならない ([04e3dba](https://github.com/tuqulore/website-boilerplate/commit/04e3dbad99207f4b20829e93894daf0a4a191ea0))
+
 
 ### Features
 
-- use 11ty, remove sass, etc. ([6e9fbe2](https://github.com/tuqulore/website-boilerplate/commit/6e9fbe2e5bc4d228ac1a226bb98d365c5b97a5f5))
+* use 11ty, remove sass, etc. ([6e9fbe2](https://github.com/tuqulore/website-boilerplate/commit/6e9fbe2e5bc4d228ac1a226bb98d365c5b97a5f5))
+
+
+


### PR DESCRIPTION
because always automatically genereted by shipjs