### PR TITLE
chore: use fast-glob instead of globby

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,12 +1,11 @@
-const globby = require("globby");
+const fg = require("fast-glob");
 const { basename, dirname } = require("path");
 const Image = require("@11ty/eleventy-img");
 
 const optimizeImages = async () => {
-  const images = await globby(
-    ["src/**/*.{jpeg,jpg,png,webp,gif,tiff,avif,svg}"],
-    { gitignore: true }
-  );
+  const images = await fg(["src/**/*.{jpeg,jpg,png,webp,gif,tiff,avif,svg}"], {
+    ignore: ["dist", "**/node_modules"],
+  });
   for (const image of images) {
     await Image(image, {
       filenameFormat: () => basename(image),

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "cachekill": "3.0.2",
     "eslint": "8.11.0",
     "eslint-config-prettier": "8.5.0",
-    "globby": "11.1.0",
+    "fast-glob": "^3.2.11",
     "npm-run-all": "4.1.5",
     "postcss": "8.4.12",
     "postcss-cli": "9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2178,18 +2178,6 @@ globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
-globby@11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
-  integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
-  dependencies:
-    array-union "^2.1.0"
-    dir-glob "^3.0.1"
-    fast-glob "^3.2.9"
-    ignore "^5.2.0"
-    merge2 "^1.4.1"
-    slash "^3.0.0"
-
 globby@^10.0.1:
   version "10.0.2"
   resolved "https://registry.yarnpkg.com/globby/-/globby-10.0.2.tgz#277593e745acaa4646c3ab411289ec47a0392543"


### PR DESCRIPTION
because globby only support es module but eleventy still not
support es module