### PR TITLE
fix: `CSS nesting has not been configured correctly`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "postcss-cli": "9.1.0",
     "postcss-csso": "6.0.0",
     "postcss-import": "14.1.0",
-    "postcss-nested": "5.0.6",
     "prettier": "2.6.0",
     "prettier-plugin-md-nocjsp": "1.2.0",
     "rimraf": "3.0.2",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -2,8 +2,8 @@ module.exports = ({ env }) => ({
   map: false,
   plugins: {
     "postcss-import": {},
+    "tailwindcss/nesting": {},
     tailwindcss: {},
-    "postcss-nested": {},
     autoprefixer: {},
     "postcss-csso": env === "production" ? {} : false,
   },


### PR DESCRIPTION
tailwindcss recommends using `tailwindcss/nesting`

See: https://tailwindcss.com/docs/using-with-preprocessors#nesting