### PR TITLE
fix: warning by postcss when unset from

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,6 @@
 module.exports = ({ env }) => ({
   map: false,
+  from: undefined,
   plugins: {
     "postcss-import": { root: "src/style" },
     "tailwindcss/nesting": {},


### PR DESCRIPTION
when run `yarn build` or `yarn dev` show as follows:

> Without `from` option PostCSS could generate wrong source map and
> will not find Browserslist config. Set it to CSS file path or
> to `undefined` to prevent this warning.