### PR TITLE
feat!: important による詳細度の上書きをおこなわない

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,6 @@ const jumpuUi = require("@jumpu-ui/tailwindcss");
 /** @type {import('tailwindcss/types').Config} */
 module.exports = {
   content: ["src/**/*.js", "src/**/*.njk", "src/**/*.md"],
-  important: true,
   theme: {
     extend: {},
   },


### PR DESCRIPTION
詳細度の上書きが必要な状況は既存の複雑なCSSが存在する場合など
必要性のある場面でおこなうべきであり
デフォルトではブラウザーによる詳細度の計算アルゴリズムにまかせるべき