### PR TITLE
feat: postcss-import-ext-glob の導入

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "npm-run-all": "4.1.5",
     "postcss": "8.4.24",
     "postcss-import": "15.1.0",
+    "postcss-import-ext-glob": "^2.1.1",
     "postcss-load-config": "4.0.1",
     "prettier": "2.8.8",
     "prettier-plugin-md-nocjsp": "1.5.1",

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -2,6 +2,7 @@ module.exports = ({ env }) => ({
   map: false,
   from: undefined,
   plugins: {
+    "postcss-import-ext-glob": {},
     "postcss-import": { root: "src/style" },
     "tailwindcss/nesting": {},
     tailwindcss: {},

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -2,4 +2,6 @@
 
 @import "tailwindcss/components";
 
+@import-glob "components/**/*.css";
+
 @import "tailwindcss/utilities";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2071,6 +2071,11 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-sort@^3.2.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/fast-sort/-/fast-sort-3.4.0.tgz#e5abb6bed199a601b34237d29db9262cdca82b3a"
+  integrity sha512-c/cMBGA5mH3OYjaXedtLIM3hQjv+KuZuiD2QEH5GofNOZeQVDIYIN7Okc2AW1KPhk44g5PTZnXp8t2lOMl8qhQ==
+
 fast-url-parser@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/fast-url-parser/-/fast-url-parser-1.1.3.tgz#f4af3ea9f34d8a271cf58ad2b3759f431f0b318d"
@@ -4168,6 +4173,15 @@ postcss-discard-overridden@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/postcss-discard-overridden/-/postcss-discard-overridden-6.0.0.tgz#49c5262db14e975e349692d9024442de7cd8e234"
   integrity sha512-4VELwssYXDFigPYAZ8vL4yX4mUepF/oCBeeIT4OXsJPYOtvJumyz9WflmJWTfDwCUcpDR+z0zvCWBXgTx35SVw==
+
+postcss-import-ext-glob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-import-ext-glob/-/postcss-import-ext-glob-2.1.1.tgz#327b83525a39ad186f9b828035ccf61f8ab57081"
+  integrity sha512-qd4ELOx2G0hyjgtmLnf/fSVJXXPhkcxcxhLT1y1mAnk53JYbMLoGg+AFtnJowOSvnv4CvjPAzpLpAcfWeofP5g==
+  dependencies:
+    fast-glob "^3.2.12"
+    fast-sort "^3.2.0"
+    postcss-value-parser "^4.2.0"
 
 postcss-import@15.1.0, postcss-import@^15.1.0:
   version "15.1.0"


### PR DESCRIPTION
resolve #369

glob パターンでの複数 CSS ファイルのインポートを可能にします