### PR TITLE
feat!: formatDate → date

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -21,9 +21,7 @@ const optimizeImages = async () => {
 };
 
 module.exports = (eleventyConfig) => {
-  eleventyConfig.addFilter("date", (date) =>
-    date.toLocaleDateString("ja-JP")
-  );
+  eleventyConfig.addFilter("date", (date) => date.toLocaleDateString("ja-JP"));
   eleventyConfig.addNunjucksAsyncFilter("postcss", (css, callback) =>
     postcssrc().then(({ plugins, options }) => {
       postcss(plugins)

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -21,7 +21,7 @@ const optimizeImages = async () => {
 };
 
 module.exports = (eleventyConfig) => {
-  eleventyConfig.addFilter("formatDate", (date) =>
+  eleventyConfig.addFilter("date", (date) =>
     date.toLocaleDateString("ja-JP")
   );
   eleventyConfig.addNunjucksAsyncFilter("postcss", (css, callback) =>


### PR DESCRIPTION
resolve #363

以下の観点で Eleventy フィルターの名前を見直します

* 日付の書式変更はよく使うので短い名前がいいのでは
* 標準で提供される url フィルターと同じように名詞のみに揃えておく