### PR TITLE
fix: src/public が画像最適化の対象に意図せず含まれる

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -6,7 +6,7 @@ const postcssrc = require("postcss-load-config");
 
 const optimizeImages = async () => {
   const images = await fg(["src/**/*.{jpeg,jpg,png,webp,gif,tiff,avif,svg}"], {
-    ignore: ["dist", "**/node_modules"],
+    ignore: ["dist", "**/node_modules", "src/public"],
   });
   for (const image of images) {
     await Image(image, {


### PR DESCRIPTION
あくまで静的アセットをそのまま配信する目的なので
むしろ画像最適化するべきではない