### PR TITLE
fix: ビルド後の JavaScript が静的コード検査される

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 !.eslintrc.js
+dist


### PR DESCRIPTION
編集するビルド前のスクリプトに対してのみ検査し
重複での検査を避ける目的