### PR TITLE
テンプレートの更新に応じた TailwindCSS による CSS 生成のサポート

### DIFF
--- a/eleventy.config.mjs
+++ b/eleventy.config.mjs
@@ -64,6 +64,9 @@ export default (eleventyConfig) => {
   });
   eleventyConfig.on("eleventy.before", optimizeImages);
   eleventyConfig.on("eleventy.before", transformJsx);
+  eleventyConfig.setServerOptions({
+    watch: ["dist/**/*.css"],
+  });
   return {
     dir: {
       input: "src",

--- a/lib/css.mjs
+++ b/lib/css.mjs
@@ -1,9 +1,12 @@
+import fg from "fast-glob";
 import postcss from "postcss";
 import postcssrc from "postcss-load-config";
 
 export default {
   outputFileExtension: "css",
-  compile: async (content, inputPath) => {
+  compile: async function (content, inputPath) {
+    const deps = await fg(["src/**/*.{md,mdx,jsx}"]);
+    this.addDependencies(inputPath, deps);
     const { plugins, options } = await postcssrc();
     const result = await postcss(plugins).process(content, {
       ...options,


### PR DESCRIPTION
次の変更によりサポートされます:

- 依存関係にテンプレートファイルを指定
- dev server の監視対象に生成された CSS を指定