### PR TITLE
開発環境でホットリロード後にPartial Hydrationが機能しない問題の修正 (#823)

### DIFF
--- a/src/_includes/base.mdx
+++ b/src/_includes/base.mdx
@@ -73,10 +73,14 @@ import Footer from "./partials/footer.mdx";
       Island.attributePrefix = "land-on:";
 
       const mount = async (target) => {
-        const component = await import(target.getAttribute("import"));
-        const propsAttr = target.getAttribute("props");
-        const props = propsAttr ? JSON.parse(propsAttr) : {};
-        hydrate(h(component.default, props), target);
+        try {
+          const component = await import(target.getAttribute("import"));
+          const propsAttr = target.getAttribute("props");
+          const props = propsAttr ? JSON.parse(propsAttr) : {};
+          hydrate(h(component.default, props), target);
+        } catch (e) {
+          console.error("Failed to mount component:", e);
+        }
       };
 
       Island.addInitType("preact", mount);


### PR DESCRIPTION
fix #823

Eleventy Dev Serverのmorphdomによるホットリロード後、is-landの
ハイドレーションが再実行されない問題を修正。

- WebSocketをフックしてeleventy.reloadメッセージを検出
- morphdom完了後に全is-land要素を再ハイドレーション
- 開発環境(NODE_ENV=development)でのみ有効