### PR TITLE
fix: add git commit after version bump in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,7 @@ jobs:
         run: |
           git checkout -b release
           pnpm versionup ${{ inputs.semver }} --yes --no-git-tag-version
+          git commit --all --message "chore(release): v$(cat lerna.json | jq -r .version)"
           git push -f origin release
 
       - name: Create pull request


### PR DESCRIPTION
## Summary

- release.yamlでversionup後にgit commitが抜けていたため、releaseブランチにmainと差分がなくPR作成に失敗していた問題を修正

## 原因

`pnpm versionup --no-git-tag-version`はファイルを変更するがコミットは作成しない。そのため、変更をコミットせずにプッシュすると、releaseブランチにはmainと同じコミットしか含まれず、PRを作成できない。

## 修正内容

versionup後に明示的に`git commit`を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)