### PR TITLE
fix: update template eleventy-preset version in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,12 @@ jobs:
         run: |
           git checkout -b release
           pnpm versionup ${{ inputs.semver }} --yes --no-git-tag-version
-          git commit --all --message "chore(release): v$(cat lerna.json | jq -r .version)"
+          VERSION=$(cat lerna.json | jq -r .version)
+          # テンプレート内の@tuqulore-inc/eleventy-presetのバージョンを更新
+          jq --arg version "^$VERSION" '.devDependencies["@tuqulore-inc/eleventy-preset"] = $version' \
+            packages/create-eleventy/templates/default/package.json > tmp.json && \
+            mv tmp.json packages/create-eleventy/templates/default/package.json
+          git commit --all --message "chore(release): v${VERSION}"
           git push -f origin release
 
       - name: Create pull request


### PR DESCRIPTION
## Summary
- リリースワークフローでバージョンバンプ後、テンプレート内の`@tuqulore-inc/eleventy-preset`の依存関係バージョンを自動更新するように修正

## Background
v4.0.0リリース後も、`packages/create-eleventy/templates/default/package.json`の`@tuqulore-inc/eleventy-preset`が`^3.0.0`のままになっていた。これにより、`pnpm create @tuqulore/eleventy`で環境構築しても古いバージョンがインストールされる問題があった。

## Changes
`release.yaml`のバージョンバンプステップで、`jq`を使用してテンプレート内の依存関係バージョンを`^新バージョン`に更新するように修正。

## Test plan
- [ ] 次回のリリースワークフロー実行時にテンプレートのpackage.jsonが正しく更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)