### PR TITLE
fix(publish): alpha版をlatestではなくalphaのdist-tagで公開する

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,7 +54,14 @@ jobs:
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: Publish to npm
-        run: pnpm packages:publish --yes
+        run: |
+          VERSION=$(cat lerna.json | jq -r .version)
+          if [[ "$VERSION" == *"-alpha."* ]]; then
+            DIST_TAG="alpha"
+          else
+            DIST_TAG="latest"
+          fi
+          pnpm packages:publish --yes --dist-tag "${DIST_TAG}"
         env:
           NPM_CONFIG_PROVENANCE: true
 


### PR DESCRIPTION
## Summary

- バージョン文字列に `-alpha.` が含まれる場合は dist-tag を `alpha` に、それ以外は `latest` に設定 (fix #862)

## Test plan

- [ ] `chore(release):` PRをマージして `publish.yaml` が実行され、`latest` dist-tag で公開されることを確認
- [ ] `workflow_dispatch` で alpha版を公開し、`alpha` dist-tag で公開されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)