### PR TITLE
feat(postcss): add skip option to bypass processing per template

### DIFF
--- a/packages/eleventy-plugin-postcss/README.md
+++ b/packages/eleventy-plugin-postcss/README.md
@@ -52,6 +52,19 @@ eleventyConfig.setServerOptions({
 });
 ```
 
+### `skip`
+
+- Type: `(inputPath: string) => boolean`
+- Default: `undefined`
+
+Predicate invoked for each CSS template file. When it returns `true`, processing and output of that file are skipped. Useful for excluding partials or files handled by another pipeline (e.g., `@import`ed fragments).
+
+```javascript
+eleventyConfig.addPlugin(postcss, {
+  skip: (inputPath) => inputPath.includes("/_partials/"),
+});
+```
+
 ## Requirements
 
 - Eleventy 3.0 or higher

--- a/packages/eleventy-plugin-postcss/index.d.ts
+++ b/packages/eleventy-plugin-postcss/index.d.ts
@@ -7,6 +7,11 @@ export interface PluginOptions {
    * Useful for TailwindCSS which scans content files for class names.
    */
   contentGlob?: string | string[];
+  /**
+   * Predicate invoked for each CSS template file.
+   * When it returns `true`, processing (and output) of that file is skipped.
+   */
+  skip?: (inputPath: string) => boolean;
 }
 
 /**

--- a/packages/eleventy-plugin-postcss/index.mjs
+++ b/packages/eleventy-plugin-postcss/index.mjs
@@ -7,6 +7,7 @@ import postcssrc from "postcss-load-config";
  * @param {import("@11ty/eleventy").UserConfig} eleventyConfig - Eleventy configuration object
  * @param {Object} pluginOptions - Plugin options
  * @param {string|string[]} [pluginOptions.contentGlob] - Glob patterns for dependency tracking
+ * @param {(inputPath: string) => boolean} [pluginOptions.skip] - Predicate to skip processing for matched CSS templates
  */
 export default function (eleventyConfig, pluginOptions = {}) {
   try {
@@ -15,7 +16,7 @@ export default function (eleventyConfig, pluginOptions = {}) {
     console.log(`[eleventy-plugin-postcss] WARN: ${e.message}`);
   }
 
-  const { contentGlob = [] } = pluginOptions;
+  const { contentGlob = [], skip } = pluginOptions;
   const contentPatterns = Array.isArray(contentGlob)
     ? contentGlob
     : [contentGlob];
@@ -24,6 +25,9 @@ export default function (eleventyConfig, pluginOptions = {}) {
   eleventyConfig.addExtension("css", {
     outputFileExtension: "css",
     compile: async function (content, inputPath) {
+      if (typeof skip === "function" && skip(inputPath)) {
+        return;
+      }
       if (contentPatterns.length > 0) {
         const deps = await fg(contentPatterns);
         this.addDependencies(inputPath, deps);


### PR DESCRIPTION
## Summary
- Add `skip?: (inputPath: string) => boolean` to `eleventy-plugin-postcss` options.
- When `skip` returns `true`, the matched CSS template is not processed by PostCSS and no output is written.
- Update `index.d.ts` and README accordingly.

## Test plan
- [ ] Run a build with `skip` unset and confirm existing behavior is unchanged.
- [ ] Run a build with `skip: (p) => p.includes("/_partials/")` and confirm matched files are neither transformed nor emitted.
- [ ] Verify `contentGlob` dependency tracking still works for non-skipped files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)