### PR TITLE
ci: リリースフローを複合アクションに置き換え（試験運用）

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,10 +48,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure git
-        run: |
-          git config --global user.name "${{ github.actor }}"
-          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+      # 試験運用: tuqulore/.github#15 のブランチを参照
+      - uses: tuqulore/.github/configure-git@add-releasing-composite-action
 
       - name: Publish to npm
         run: |
@@ -73,22 +71,17 @@ jobs:
           git tag "v${VERSION}"
           git push origin "v${VERSION}"
 
-      - name: Create alpha branch and bump version
-        run: |
-          git checkout main
-          git pull origin main
-          git checkout -B alpha
-          pnpm packages:bump-version prerelease --preid alpha --yes --no-git-tag-version
-          git commit --all --message "chore(alpha): v$(cat lerna.json | jq -r .version)"
-          git push -f origin alpha
+      # 試験運用: tuqulore/.github#15 のブランチを参照
+      # 直前の "Create release tag" が main を checkout 済みのため、そこから alpha ブランチを作成する
+      - uses: tuqulore/.github/bump-and-pr@add-releasing-composite-action
+        with:
+          branch: alpha
+          bump-command: pnpm packages:bump-version prerelease --preid alpha --yes --no-git-tag-version
+          version-command: jq -r .version lerna.json
+          commit-prefix: chore(alpha)
+          pr-body: Bump to alpha version v${VERSION}
+          github-token: ${{ github.token }}
 
-      - name: Create alpha pull request
-        run: |
-          VERSION=$(cat lerna.json | jq -r .version)
-          gh pr create \
-            --base main \
-            --head alpha \
-            --title "chore(alpha): v${VERSION}" \
-            --body "Bump to alpha version v${VERSION}"
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Cleanup alpha branch on failure or cancellation
+        if: failure() || cancelled()
+        run: git push origin :alpha || true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,32 +25,24 @@ jobs:
     steps:
       - uses: tuqulore/.github/setup@bfc3a44941a6d4499735fa48c913b51c15f9ca7b # main
 
-      - name: Configure git
-        run: |
-          git config --global user.name "${{ github.actor }}"
-          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+      # 試験運用: tuqulore/.github#15 のブランチを参照
+      - uses: tuqulore/.github/configure-git@add-releasing-composite-action
 
-      - name: Create release branch and bump version
-        run: |
-          git checkout -b release
-          pnpm packages:bump-version ${{ inputs.semver }} --yes --no-git-tag-version
-          VERSION=$(cat lerna.json | jq -r .version)
+      # 試験運用: tuqulore/.github#15 のブランチを参照
+      - uses: tuqulore/.github/bump-and-pr@add-releasing-composite-action
+        with:
+          branch: release
+          bump-command: pnpm packages:bump-version ${{ inputs.semver }} --yes --no-git-tag-version
+          version-command: jq -r .version lerna.json
+          commit-prefix: chore(release)
+          pr-body: Release v${VERSION}
           # テンプレート内の@tuqulore-inc/eleventy-presetのバージョンを更新
-          jq --arg version "^$VERSION" '.devDependencies["@tuqulore-inc/eleventy-preset"] = $version' \
-            packages/create-eleventy/templates/default/package.json > tmp.json && \
+          pre-commit-command: |
+            VERSION=$(jq -r .version lerna.json)
+            jq --arg version "^$VERSION" '.devDependencies["@tuqulore-inc/eleventy-preset"] = $version' \
+              packages/create-eleventy/templates/default/package.json > tmp.json
             mv tmp.json packages/create-eleventy/templates/default/package.json
-          git commit --all --message "chore(release): v${VERSION}"
-          git push -f origin release
-
-      - name: Create pull request
-        run: |
-          VERSION=$(cat lerna.json | jq -r .version)
-          gh pr create \
-            --base main \
-            --title "chore(release): v${VERSION}" \
-            --body "Release v${VERSION}"
-        env:
-          GH_TOKEN: ${{ github.token }}
+          github-token: ${{ github.token }}
 
       - name: Cleanup on failure or cancellation
         if: failure() || cancelled()


### PR DESCRIPTION
## 概要

`release.yaml` / `publish.yaml` のリリースフローを [tuqulore/.github#15](https://github.com/tuqulore/.github/pull/15) で追加される `bump-and-pr` / `configure-git` 複合アクションに置き換える試験運用 PR。

参照は試験運用として `@add-releasing-composite-action` ブランチに固定している（PR #15 は未マージのまま動作確認できる）。

## 変更内容

### `release.yaml`
- `Configure git` ステップ → `tuqulore/.github/configure-git` に置換
- `Create release branch and bump version` + `Create pull request` → `tuqulore/.github/bump-and-pr` に集約
- テンプレートの `@tuqulore-inc/eleventy-preset` バージョン更新は `pre-commit-command` に移植
- `Cleanup on failure or cancellation` は複合アクションが `post:` を持てないため呼び出し側に残置

### `publish.yaml`
- `Configure git` ステップ → `tuqulore/.github/configure-git` に置換
- `Create alpha branch and bump version` + `Create alpha pull request` → `tuqulore/.github/bump-and-pr` に集約
- npm publish / タグ作成は複合アクションの対象外なので従来どおり
- `Cleanup alpha branch on failure or cancellation` を新規追加（非 force push 化に伴う自己修復用の安全策）

## 実行前に必要な対応

- リモートに残存している stale な `release` ブランチを削除しておくこと（非 force push のため、残っていると初回実行が push 失敗する）

## Test plan

- [x] 残存 `release` ブランチを削除
- [ ] `release.yaml` を `workflow_dispatch` で実行し `chore(release):` PR が作成されることを確認
- [ ] その PR をマージし `publish.yaml` が発火、npm publish・タグ作成・`chore(alpha):` PR 作成まで動作することを確認

## 補足

- `ci.yaml`（`format` 利用）は SHA ピン据え置きのため今回は影響なし。PR #15 マージ後に SHA 更新すると `format` が内部で `configure-git` を使う形になる。
- `publish.yaml` の alpha ステップは直前の `Create release tag` が main を checkout 済みである前提で alpha ブランチを作成する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)