### PR TITLE
ci: リリースフローの複合アクション参照を @main に更新

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,8 +48,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      # 試験運用: tuqulore/.github#15 のブランチを参照
-      - uses: tuqulore/.github/configure-git@add-releasing-composite-action
+      - uses: tuqulore/.github/configure-git@main
 
       - name: Publish to npm
         run: |
@@ -71,9 +70,8 @@ jobs:
           git tag "v${VERSION}"
           git push origin "v${VERSION}"
 
-      # 試験運用: tuqulore/.github#15 のブランチを参照
       # 直前の "Create release tag" が main を checkout 済みのため、そこから alpha ブランチを作成する
-      - uses: tuqulore/.github/bump-and-pr@add-releasing-composite-action
+      - uses: tuqulore/.github/bump-and-pr@main
         with:
           branch: alpha
           bump-command: pnpm packages:bump-version prerelease --preid alpha --yes --no-git-tag-version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,11 +25,9 @@ jobs:
     steps:
       - uses: tuqulore/.github/setup@bfc3a44941a6d4499735fa48c913b51c15f9ca7b # main
 
-      # 試験運用: tuqulore/.github#15 のブランチを参照
-      - uses: tuqulore/.github/configure-git@add-releasing-composite-action
+      - uses: tuqulore/.github/configure-git@main
 
-      # 試験運用: tuqulore/.github#15 のブランチを参照
-      - uses: tuqulore/.github/bump-and-pr@add-releasing-composite-action
+      - uses: tuqulore/.github/bump-and-pr@main
         with:
           branch: release
           bump-command: pnpm packages:bump-version ${{ inputs.semver }} --yes --no-git-tag-version


### PR DESCRIPTION
## 概要

試験運用（#876）で `tuqulore/.github#15` のブランチ `@add-releasing-composite-action` を参照していた `bump-and-pr` / `configure-git` 複合アクションを、`@main` 参照に切り替える。

## 変更内容

- `release.yaml`: `configure-git` / `bump-and-pr` の参照を `@main` に更新
- `publish.yaml`: `configure-git` / `bump-and-pr` の参照を `@main` に更新
- 試験運用を示す `# 試験運用: ...` コメントを削除

## 前提・注意

- **このPRをマージしただけでは release/publish ワークフローはまだ動作しません。** `tuqulore/.github#15` が `main` にマージされて初めて `@main` 参照が解決します。
- 運用上、本PRマージ後〜`tuqulore/.github#15` マージまでの間は release/publish ワークフローを使用しません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)