### PR TITLE
Update CI workflow to remove tags-ignore setting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,6 @@
 name: CI
 on:
   push:
-    tags-ignore:
-      - '**'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Remove tags-ignore from push event in CI workflow

tags-ignore '**' はブランチpushもskipしてしまうため、simplicityを重視して常に発火する設定にする。