### PR TITLE
test(create-eleventy): テンプレートテストを導入

### DIFF
--- a/packages/create-eleventy/cli.test.mjs
+++ b/packages/create-eleventy/cli.test.mjs
@@ -10,11 +10,19 @@ import { fileURLToPath } from "node:url";
 const here = path.dirname(fileURLToPath(import.meta.url));
 const cli = path.join(here, "index.mjs");
 
+// spawnSync は同期呼び出しなので node:test の timeout では中断できない。
+// プロンプト待ち等でハングしないよう明示的に上限を設ける。
+const SPAWN_OPTS = {
+  encoding: "utf8",
+  timeout: 30_000,
+  maxBuffer: 5 * 1024 * 1024,
+};
+
 function runCli(args, cwd) {
   return spawnSync(process.execPath, [cli, ...args], {
     cwd,
     stdio: ["ignore", "pipe", "pipe"],
-    encoding: "utf8",
+    ...SPAWN_OPTS,
   });
 }
 
@@ -26,7 +34,7 @@ describe("create-eleventy CLI", () => {
   });
 
   after(async () => {
-    await fsp.rm(workDir, { recursive: true, force: true });
+    if (workDir) await fsp.rm(workDir, { recursive: true, force: true });
   });
 
   it("--help はUsageを出力してexit 0", () => {
@@ -53,7 +61,7 @@ describe("create-eleventy CLI", () => {
     const result = spawnSync(process.execPath, [cli], {
       cwd: workDir,
       input: "\n",
-      encoding: "utf8",
+      ...SPAWN_OPTS,
     });
     assert.notStrictEqual(result.status, 0);
     assert.match(result.stderr, /Project name is required/);

--- a/packages/create-eleventy/cli.test.mjs
+++ b/packages/create-eleventy/cli.test.mjs
@@ -1,0 +1,61 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const cli = path.join(here, "index.mjs");
+
+function runCli(args, cwd) {
+  return spawnSync(process.execPath, [cli, ...args], {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+  });
+}
+
+describe("create-eleventy CLI", () => {
+  let workDir;
+
+  before(async () => {
+    workDir = await fsp.mkdtemp(path.join(os.tmpdir(), "create-eleventy-cli-"));
+  });
+
+  after(async () => {
+    await fsp.rm(workDir, { recursive: true, force: true });
+  });
+
+  it("--help はUsageを出力してexit 0", () => {
+    const result = runCli(["--help"], workDir);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Usage:/);
+  });
+
+  it("存在しないテンプレートを指定するとエラー終了する", () => {
+    const result = runCli(["my-app", "--template", "nonexistent"], workDir);
+    assert.notStrictEqual(result.status, 0);
+    assert.match(result.stderr, /not found/);
+  });
+
+  it("既存ディレクトリと同名のプロジェクト名はエラー終了する", () => {
+    const existing = path.join(workDir, "existing");
+    fs.mkdirSync(existing);
+    const result = runCli(["existing"], workDir);
+    assert.notStrictEqual(result.status, 0);
+    assert.match(result.stderr, /already exists/);
+  });
+
+  it("プロジェクト名を空入力するとエラー終了する", () => {
+    const result = spawnSync(process.execPath, [cli], {
+      cwd: workDir,
+      input: "\n",
+      encoding: "utf8",
+    });
+    assert.notStrictEqual(result.status, 0);
+    assert.match(result.stderr, /Project name is required/);
+  });
+});

--- a/packages/create-eleventy/package.json
+++ b/packages/create-eleventy/package.json
@@ -24,7 +24,8 @@
     "templates"
   ],
   "scripts": {
-    "lint": "eslint --fix ."
+    "lint": "eslint --fix .",
+    "test": "node --test"
   },
   "devDependencies": {
     "@tuqulore-inc/eslint-config": "workspace:*",

--- a/packages/create-eleventy/templates.test.mjs
+++ b/packages/create-eleventy/templates.test.mjs
@@ -76,7 +76,10 @@ describe("create-eleventy templates", { concurrency: true }, () => {
   });
 
   for (const template of templates) {
-    describe(template, () => {
+    // 外側 describe の concurrency: true は子孫にも継承されるため、
+    // ここで false を明示して scaffold → install+build を逐次に固定する。
+    // テンプレート間の並列性（外側 describe の直下）は維持したい。
+    describe(template, { concurrency: false }, () => {
       let workDir;
       let projectDir;
 

--- a/packages/create-eleventy/templates.test.mjs
+++ b/packages/create-eleventy/templates.test.mjs
@@ -26,6 +26,14 @@ const workspacePackageNames = [
   "@tuqulore-inc/eleventy-plugin-postcss",
 ];
 
+// spawnSync は同期呼び出しなので node:test の timeout では中断できない。
+// 個別に timeout / maxBuffer を渡してハングと ENOBUFS を防ぐ。
+const MAX_BUFFER = 20 * 1024 * 1024;
+const TIMEOUT_FAST = 30_000;
+const TIMEOUT_PACK = 120_000;
+const TIMEOUT_INSTALL = 240_000;
+const TIMEOUT_BUILD = 60_000;
+
 describe("create-eleventy templates", { concurrency: true }, () => {
   let packDir;
   const overrides = {};
@@ -38,7 +46,12 @@ describe("create-eleventy templates", { concurrency: true }, () => {
       const result = spawnSync(
         "pnpm",
         ["--filter", name, "pack", "--pack-destination", packDir],
-        { cwd: workspaceRoot, encoding: "utf8" },
+        {
+          cwd: workspaceRoot,
+          encoding: "utf8",
+          timeout: TIMEOUT_PACK,
+          maxBuffer: MAX_BUFFER,
+        },
       );
       assert.strictEqual(
         result.status,
@@ -75,7 +88,7 @@ describe("create-eleventy templates", { concurrency: true }, () => {
       });
 
       after(async () => {
-        await fsp.rm(workDir, { recursive: true, force: true });
+        if (workDir) await fsp.rm(workDir, { recursive: true, force: true });
       });
 
       it("CLI で scaffold できる", () => {
@@ -86,6 +99,8 @@ describe("create-eleventy templates", { concurrency: true }, () => {
             cwd: workDir,
             stdio: ["ignore", "pipe", "pipe"],
             encoding: "utf8",
+            timeout: TIMEOUT_FAST,
+            maxBuffer: MAX_BUFFER,
           },
         );
         assert.strictEqual(result.status, 0, describeChild("scaffold", result));
@@ -106,7 +121,7 @@ describe("create-eleventy templates", { concurrency: true }, () => {
 
       it(
         "現ソースの workspace パッケージで pnpm i && pnpm build が成功する",
-        { timeout: 300_000 },
+        { timeout: TIMEOUT_INSTALL + TIMEOUT_BUILD + 30_000 },
         () => {
           // pnpm 11 以降 package.json の "pnpm" フィールドは読まれないため、
           // workDir を workspace 化して pnpm-workspace.yaml に overrides を書く。
@@ -127,6 +142,8 @@ describe("create-eleventy templates", { concurrency: true }, () => {
           const install = spawnSync("pnpm", ["install", "--prefer-offline"], {
             cwd: projectDir,
             encoding: "utf8",
+            timeout: TIMEOUT_INSTALL,
+            maxBuffer: MAX_BUFFER,
           });
           assert.strictEqual(
             install.status,
@@ -137,6 +154,8 @@ describe("create-eleventy templates", { concurrency: true }, () => {
           const build = spawnSync("pnpm", ["run", "build"], {
             cwd: projectDir,
             encoding: "utf8",
+            timeout: TIMEOUT_BUILD,
+            maxBuffer: MAX_BUFFER,
           });
           assert.strictEqual(
             build.status,

--- a/packages/create-eleventy/templates.test.mjs
+++ b/packages/create-eleventy/templates.test.mjs
@@ -1,0 +1,106 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const cli = path.join(here, "index.mjs");
+const templatesDir = path.join(here, "templates");
+
+const templates = fs
+  .readdirSync(templatesDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name);
+
+describe("create-eleventy templates", { concurrency: true }, () => {
+  it("templates ディレクトリが1つ以上ある", () => {
+    assert.ok(templates.length > 0, `templates が空: ${templatesDir}`);
+  });
+
+  for (const template of templates) {
+    describe(template, () => {
+      let workDir;
+      let projectDir;
+
+      before(async () => {
+        workDir = await fsp.mkdtemp(
+          path.join(os.tmpdir(), `create-eleventy-${template}-`),
+        );
+        projectDir = path.join(workDir, "my-app");
+      });
+
+      after(async () => {
+        await fsp.rm(workDir, { recursive: true, force: true });
+      });
+
+      it("CLI で scaffold できる", () => {
+        const result = spawnSync(
+          process.execPath,
+          [cli, "my-app", "--template", template],
+          {
+            cwd: workDir,
+            stdio: ["ignore", "pipe", "pipe"],
+            encoding: "utf8",
+          },
+        );
+        assert.strictEqual(
+          result.status,
+          0,
+          describeChild("scaffold", result),
+        );
+
+        const pkg = JSON.parse(
+          fs.readFileSync(path.join(projectDir, "package.json"), "utf8"),
+        );
+        assert.strictEqual(pkg.name, "my-app");
+        assert.ok(
+          fs.existsSync(path.join(projectDir, ".env")),
+          "_env が .env にリネームされていない",
+        );
+        assert.ok(
+          fs.existsSync(path.join(projectDir, ".gitignore")),
+          "_gitignore が .gitignore にリネームされていない",
+        );
+      });
+
+      it("pnpm i && pnpm build が成功する", { timeout: 300_000 }, () => {
+        const install = spawnSync(
+          "pnpm",
+          ["install", "--ignore-workspace", "--prefer-offline"],
+          { cwd: projectDir, encoding: "utf8" },
+        );
+        assert.strictEqual(
+          install.status,
+          0,
+          describeChild("pnpm install", install),
+        );
+
+        const build = spawnSync("pnpm", ["run", "build"], {
+          cwd: projectDir,
+          encoding: "utf8",
+        });
+        assert.strictEqual(build.status, 0, describeChild("pnpm build", build));
+
+        assert.ok(
+          fs.existsSync(path.join(projectDir, "dist", "index.html")),
+          "build 後に dist/index.html が生成されていない",
+        );
+      });
+    });
+  }
+});
+
+function describeChild(label, result) {
+  return [
+    `[${label}] status=${result.status}`,
+    result.error ? `error=${result.error.message}` : "",
+    result.stdout ? `stdout=\n${result.stdout}` : "",
+    result.stderr ? `stderr=\n${result.stderr}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}

--- a/packages/create-eleventy/templates.test.mjs
+++ b/packages/create-eleventy/templates.test.mjs
@@ -88,11 +88,7 @@ describe("create-eleventy templates", { concurrency: true }, () => {
             encoding: "utf8",
           },
         );
-        assert.strictEqual(
-          result.status,
-          0,
-          describeChild("scaffold", result),
-        );
+        assert.strictEqual(result.status, 0, describeChild("scaffold", result));
 
         const pkg = JSON.parse(
           fs.readFileSync(path.join(projectDir, "package.json"), "utf8"),
@@ -128,11 +124,10 @@ describe("create-eleventy templates", { concurrency: true }, () => {
             workspaceYaml,
           );
 
-          const install = spawnSync(
-            "pnpm",
-            ["install", "--prefer-offline"],
-            { cwd: projectDir, encoding: "utf8" },
-          );
+          const install = spawnSync("pnpm", ["install", "--prefer-offline"], {
+            cwd: projectDir,
+            encoding: "utf8",
+          });
           assert.strictEqual(
             install.status,
             0,

--- a/packages/create-eleventy/templates.test.mjs
+++ b/packages/create-eleventy/templates.test.mjs
@@ -10,13 +10,54 @@ import { fileURLToPath } from "node:url";
 const here = path.dirname(fileURLToPath(import.meta.url));
 const cli = path.join(here, "index.mjs");
 const templatesDir = path.join(here, "templates");
+const workspaceRoot = path.resolve(here, "..", "..");
 
 const templates = fs
   .readdirSync(templatesDir, { withFileTypes: true })
   .filter((entry) => entry.isDirectory())
   .map((entry) => entry.name);
 
+// テンプレートが直接/間接に依存する workspace 内パッケージ。
+// eleventy-preset が workspace:* で 3 プラグインを引くため一括で差し込む。
+const workspacePackageNames = [
+  "@tuqulore-inc/eleventy-preset",
+  "@tuqulore-inc/eleventy-plugin-preact",
+  "@tuqulore-inc/eleventy-plugin-preact-island",
+  "@tuqulore-inc/eleventy-plugin-postcss",
+];
+
 describe("create-eleventy templates", { concurrency: true }, () => {
+  let packDir;
+  const overrides = {};
+
+  before(async () => {
+    packDir = await fsp.mkdtemp(
+      path.join(os.tmpdir(), "create-eleventy-pack-"),
+    );
+    for (const name of workspacePackageNames) {
+      const result = spawnSync(
+        "pnpm",
+        ["--filter", name, "pack", "--pack-destination", packDir],
+        { cwd: workspaceRoot, encoding: "utf8" },
+      );
+      assert.strictEqual(
+        result.status,
+        0,
+        describeChild(`pnpm pack ${name}`, result),
+      );
+      const shortName = name.replace("@tuqulore-inc/", "tuqulore-inc-");
+      const tarball = fs
+        .readdirSync(packDir)
+        .find((f) => f.startsWith(`${shortName}-`) && f.endsWith(".tgz"));
+      assert.ok(tarball, `tarball not found for ${name} in ${packDir}`);
+      overrides[name] = `file:${path.join(packDir, tarball)}`;
+    }
+  });
+
+  after(async () => {
+    if (packDir) await fsp.rm(packDir, { recursive: true, force: true });
+  });
+
   it("templates ディレクトリが1つ以上ある", () => {
     assert.ok(templates.length > 0, `templates が空: ${templatesDir}`);
   });
@@ -67,29 +108,48 @@ describe("create-eleventy templates", { concurrency: true }, () => {
         );
       });
 
-      it("pnpm i && pnpm build が成功する", { timeout: 300_000 }, () => {
-        const install = spawnSync(
-          "pnpm",
-          ["install", "--ignore-workspace", "--prefer-offline"],
-          { cwd: projectDir, encoding: "utf8" },
-        );
-        assert.strictEqual(
-          install.status,
-          0,
-          describeChild("pnpm install", install),
-        );
+      it(
+        "現ソースの workspace パッケージで pnpm i && pnpm build が成功する",
+        { timeout: 300_000 },
+        () => {
+          // scaffold 済み package.json に pnpm.overrides を差し込み、
+          // 公開済みバージョンではなく現ブランチの workspace パッケージを
+          // pack した tarball を install に流す。
+          const pkgPath = path.join(projectDir, "package.json");
+          const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+          pkg.pnpm = {
+            ...pkg.pnpm,
+            overrides: { ...pkg.pnpm?.overrides, ...overrides },
+          };
+          fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
 
-        const build = spawnSync("pnpm", ["run", "build"], {
-          cwd: projectDir,
-          encoding: "utf8",
-        });
-        assert.strictEqual(build.status, 0, describeChild("pnpm build", build));
+          const install = spawnSync(
+            "pnpm",
+            ["install", "--ignore-workspace", "--prefer-offline"],
+            { cwd: projectDir, encoding: "utf8" },
+          );
+          assert.strictEqual(
+            install.status,
+            0,
+            describeChild("pnpm install", install),
+          );
 
-        assert.ok(
-          fs.existsSync(path.join(projectDir, "dist", "index.html")),
-          "build 後に dist/index.html が生成されていない",
-        );
-      });
+          const build = spawnSync("pnpm", ["run", "build"], {
+            cwd: projectDir,
+            encoding: "utf8",
+          });
+          assert.strictEqual(
+            build.status,
+            0,
+            describeChild("pnpm build", build),
+          );
+
+          assert.ok(
+            fs.existsSync(path.join(projectDir, "dist", "index.html")),
+            "build 後に dist/index.html が生成されていない",
+          );
+        },
+      );
     });
   }
 });

--- a/packages/create-eleventy/templates.test.mjs
+++ b/packages/create-eleventy/templates.test.mjs
@@ -112,20 +112,25 @@ describe("create-eleventy templates", { concurrency: true }, () => {
         "現ソースの workspace パッケージで pnpm i && pnpm build が成功する",
         { timeout: 300_000 },
         () => {
-          // scaffold 済み package.json に pnpm.overrides を差し込み、
-          // 公開済みバージョンではなく現ブランチの workspace パッケージを
-          // pack した tarball を install に流す。
-          const pkgPath = path.join(projectDir, "package.json");
-          const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
-          pkg.pnpm = {
-            ...pkg.pnpm,
-            overrides: { ...pkg.pnpm?.overrides, ...overrides },
-          };
-          fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+          // pnpm 11 以降 package.json の "pnpm" フィールドは読まれないため、
+          // workDir を workspace 化して pnpm-workspace.yaml に overrides を書く。
+          // allowBuilds はリポジトリルートの workspace 設定を踏襲し、
+          // esbuild / sharp の build script 未実行によるハードエラーを抑制する。
+          const overridesYaml = Object.entries(overrides)
+            .map(([name, target]) => `  "${name}": "${target}"`)
+            .join("\n");
+          const workspaceYaml =
+            `packages:\n  - my-app\n` +
+            `overrides:\n${overridesYaml}\n` +
+            `allowBuilds:\n  esbuild: false\n  sharp: false\n`;
+          fs.writeFileSync(
+            path.join(workDir, "pnpm-workspace.yaml"),
+            workspaceYaml,
+          );
 
           const install = spawnSync(
             "pnpm",
-            ["install", "--ignore-workspace", "--prefer-offline"],
+            ["install", "--prefer-offline"],
             { cwd: projectDir, encoding: "utf8" },
           );
           assert.strictEqual(


### PR DESCRIPTION
Closes #884

## Summary

`packages/create-eleventy/templates/*` に対する自動テストがなく、テンプレート同梱物の破損や workspace パッケージの破壊的変更がリリース後にしか発覚しなかった。本 PR で `pnpm -r test` に組み込まれる Node 標準テスト (`node --test`) を追加する。

- **`templates.test.mjs`** — 各テンプレートに対し以下を実行:
  1. CLI (`index.mjs`) で tmpdir 内に scaffold
  2. `package.json.name` / `.env` / `.gitignore` を検証（scaffold 特有のリグレッション検知）
  3. `pnpm install` → `pnpm run build` を実行し `dist/index.html` の生成を確認
- **`cli.test.mjs`** — CLI エラー系 4 ケース（不明テンプレート、既存ディレクトリ、空プロジェクト名、`--help`）を単体テスト
- **`package.json`** — `"test": "node --test"` を追加

### リリース**前**の検証を担保する仕組み

テンプレートは `@tuqulore-inc/eleventy-preset: ^4.1.0` を参照しており、素の `pnpm install` では公開済み版が入る。これでは現ブランチの workspace パッケージが検証されないため、以下の手順で現ソースを差し込んでいる:

1. `pnpm --filter <name> pack --pack-destination <tmpDir>` で `@tuqulore-inc/eleventy-preset` と依存する 3 プラグインを tarball 化（`workspace:*` は pack 時に実バージョンへ解決される）
2. scaffold 後、tmpdir に `pnpm-workspace.yaml` を書き、`overrides` に上記 tarball への `file:` を、`allowBuilds` にリポジトリルートと同じ `{ esbuild: false, sharp: false }` を設定
3. `overrides` は transitive にも効くため、テンプレートが直接依存していない plugin 群も一括で差し替わる

> pnpm 11 系では `package.json` の `pnpm` フィールドが読まれなくなったため、overrides は `pnpm-workspace.yaml` 側に置く必要がある。

意図的に `packages/eleventy-preset/index.mjs` に `throw` を挿入して build テストが赤化することをローカルで確認済。

### 堅牢性

- `spawnSync` は同期呼び出しなので `node:test` の it 単位タイムアウトでは中断できない。pack / scaffold / install / build / CLI 呼び出しすべてに個別の `timeout` と `maxBuffer` を設定してハングと ENOBUFS を防ぐ
- テンプレート間は `concurrency: true` で並列、テンプレート内（scaffold → install+build）は `concurrency: false` で逐次を明示（`node:test` の concurrency は子孫に継承されるため）
- `after` フックは `workDir` / `packDir` の未初期化ガード付きで cleanup

### CI

`.github/workflows/ci.yaml` の `pnpm -r test` が既存の workflow のまま自動的に新テストを拾うため、CI 定義の変更は不要。

## Test plan

- [x] `cd packages/create-eleventy && pnpm test` — 全 7 テスト pass、warm cache で ~3 秒
- [x] リポジトリルートで `pnpm -r test` — 既存の `eleventy-plugin-preact` 19 テスト + 新規 7 テスト、全 pass
- [x] `packages/eleventy-preset/index.mjs` に故意の `throw` を挿入 → build テストが赤化することを確認 → `git restore` で復元
- [x] tmpdir が cleanup されることを確認 (`ls /tmp/create-eleventy-*` が空)

🤖 Generated with [Claude Code](https://claude.com/claude-code)