### PR TITLE
feat(eleventy-plugin-preact-island): Island ラッパーで Partial Hydration を簡潔化する

### DIFF
--- a/packages/create-eleventy/templates/default/src/__includes/partials/header.mdx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header.mdx
@@ -1,3 +1,4 @@
+import { Island } from "@tuqulore-inc/eleventy-preset/island";
 import { eleventy } from "@tuqulore-inc/eleventy-preset/eleventy";
 import Desktop from "./header/desktop.hydrate.jsx";
 import Mobile from "./header/mobile.hydrate.jsx";
@@ -7,24 +8,17 @@ import Mobile from "./header/mobile.hydrate.jsx";
     <a class="flex-shrink-0" href="/">
       {eleventy.site.name}
     </a>
-    <is-land
-      land-on:interaction
-      type="preact"
-      import="/_includes/partials/header/desktop.hydrate.js"
-      props={JSON.stringify({ class: "hidden md:block", nav: eleventy.nav })}
-    >
-      <Desktop class="hidden md:block" nav={eleventy.nav} />
-    </is-land>
-    <is-land
-      land-on:interaction
-      type="preact"
-      import="/_includes/partials/header/mobile.hydrate.js"
-      props={JSON.stringify({
-        class: "ml-auto flex items-center md:hidden",
-        nav: eleventy.nav,
-      })}
-    >
-      <Mobile class="ml-auto flex items-center md:hidden" nav={eleventy.nav} />
-    </is-land>
+    <Island
+      component={Desktop}
+      on="interaction"
+      class="hidden md:block"
+      nav={eleventy.nav}
+    />
+    <Island
+      component={Mobile}
+      on="interaction"
+      class="ml-auto flex items-center md:hidden"
+      nav={eleventy.nav}
+    />
   </div>
 </header>

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.hydrate.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.hydrate.jsx
@@ -1,3 +1,4 @@
+import { hydratable } from "@tuqulore-inc/eleventy-preset/island";
 import { useState, useRef, useEffect } from "preact/hooks";
 import slugify from "slugify";
 import { twMerge } from "tailwind-merge";
@@ -47,7 +48,7 @@ function MenuList(props) {
   );
 }
 
-export default function Desktop(props) {
+function Desktop(props) {
   return (
     <nav class={props.class}>
       <ul class="flex items-center">
@@ -79,3 +80,5 @@ export default function Desktop(props) {
     </nav>
   );
 }
+
+export default hydratable(Desktop, import.meta.url);

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.hydrate.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.hydrate.jsx
@@ -1,7 +1,8 @@
+import { hydratable } from "@tuqulore-inc/eleventy-preset/island";
 import { useState } from "preact/hooks";
 import { twMerge } from "tailwind-merge";
 
-export default function Mobile(props) {
+function Mobile(props) {
   const [open, setOpen] = useState(false);
   return (
     <div class={props.class}>
@@ -74,3 +75,5 @@ export default function Mobile(props) {
     </div>
   );
 }
+
+export default hydratable(Mobile, import.meta.url);

--- a/packages/create-eleventy/templates/default/src/clicker.hydrate.jsx
+++ b/packages/create-eleventy/templates/default/src/clicker.hydrate.jsx
@@ -1,6 +1,7 @@
+import { hydratable } from "@tuqulore-inc/eleventy-preset/island";
 import { useState } from "preact/hooks";
 
-export default function Clicker() {
+function Clicker() {
   const [counter, setCounter] = useState(0);
 
   return (
@@ -12,3 +13,5 @@ export default function Clicker() {
     </div>
   );
 }
+
+export default hydratable(Clicker, import.meta.url);

--- a/packages/create-eleventy/templates/default/src/index.mdx
+++ b/packages/create-eleventy/templates/default/src/index.mdx
@@ -1,3 +1,4 @@
+import { Island } from "@tuqulore-inc/eleventy-preset/island";
 import Clicker from "./clicker.hydrate.jsx";
 
 export const data = {
@@ -15,6 +16,4 @@ export const data = {
 
 Hello World
 
-<is-land land-on:interaction type="preact" import="./clicker.hydrate.js">
-  <Clicker />
-</is-land>
+<Island component={Clicker} on="interaction" />

--- a/packages/eleventy-plugin-preact-island/README.md
+++ b/packages/eleventy-plugin-preact-island/README.md
@@ -2,12 +2,15 @@
 
 Eleventy plugin for Preact partial hydration with is-land.
 
-This plugin automatically injects the necessary scripts for Preact hydration into all HTML pages.
+This plugin:
+
+1. Injects the browser-side setup for [`@11ty/is-land`](https://github.com/11ty/is-land) + Preact into every HTML page.
+2. Ships an `<Island>` wrapper component that eliminates the `<is-land>` boilerplate (`type="preact"`, hardcoded `import` URL, `JSON.stringify(props)`, duplicate SSR children).
 
 ## Installation
 
 ```bash
-npm install -D @11ty/eleventy @tuqulore-inc/eleventy-plugin-preact-island
+npm install -D @11ty/eleventy preact @tuqulore-inc/eleventy-plugin-preact-island
 ```
 
 ## Usage
@@ -28,6 +31,7 @@ export default function (eleventyConfig) {
    - Import map for is-land and Preact (from esm.sh CDN)
    - Development-only WebSocket hook for rehydration after hot reload
    - is-land setup script with `Island.addInitType("preact", mount)`
+3. **Registers a hydrate module URL resolver** used by the `<Island>` component (see below).
 
 ## Options
 
@@ -44,42 +48,96 @@ eleventyConfig.addPlugin(preactIsland, {
 });
 ```
 
+### `resolveHydrateUrl`
+
+- Type: `(moduleUrl: string) => string`
+- Default: `createHydrateModuleResolver()` (`srcDir: "src"`, `urlPrefix: "/"`)
+
+Convert an SSR-side hydrate module URL (e.g. `import.meta.url` inside `foo.hydrate.jsx`) into the browser URL where the compiled bundle is served. When using this plugin outside `@tuqulore-inc/eleventy-preset`, pass a resolver that matches your build convention.
+
+```javascript
+import preactIsland from "@tuqulore-inc/eleventy-plugin-preact-island";
+import { createHydrateModuleResolver } from "@tuqulore-inc/eleventy-plugin-preact-island/resolver";
+
+eleventyConfig.addPlugin(preactIsland, {
+  resolveHydrateUrl: createHydrateModuleResolver({
+    srcDir: "content",
+    urlPrefix: "/assets",
+  }),
+});
+```
+
+Or supply an arbitrary function:
+
+```javascript
+eleventyConfig.addPlugin(preactIsland, {
+  resolveHydrateUrl: (moduleUrl) =>
+    moduleUrl.replace(/^.*\/pages\//, "/build/").replace(/\.jsx$/, ".js"),
+});
+```
+
 ## Partial Hydration
 
-To hydrate a component, use the `<is-land>` web component with `type="preact"`.
+### `hydratable(Component, moduleUrl)`
 
-```mdx
-import Component from "./component.hydrate.jsx";
+Marks a component as hydratable by attaching its SSR-side module URL. Call once in each `*.hydrate.jsx` file:
 
+```jsx
+// src/counter.hydrate.jsx
+import { hydratable } from "@tuqulore-inc/eleventy-plugin-preact-island/island";
+import { useState } from "preact/hooks";
+
+function Counter() {
+  const [n, setN] = useState(0);
+  return <button onClick={() => setN(n + 1)}>{n}</button>;
+}
+
+export default hydratable(Counter, import.meta.url);
+```
+
+### `<Island>`
+
+Wrap a hydratable component in `<is-land>`. Extra props are forwarded to both the SSR render and the client hydration.
+
+```jsx
+import { Island } from "@tuqulore-inc/eleventy-plugin-preact-island/island";
+import Counter from "./counter.hydrate.jsx";
+
+<Island component={Counter} on="interaction" label="click me" />;
+```
+
+The example renders (after resolving the import URL):
+
+```html
 <is-land
-land-on:visible
-type="preact"
-import="./component.hydrate.js"
-props='{ "someProp": "value" }'
-
+  land-on:interaction
+  type="preact"
+  import="/counter.hydrate.js"
+  props='{"label":"click me"}'
 >
-
-  <Component someProp="value" />
+  <button>0</button>
 </is-land>
 ```
 
-- The inner `<Component />` is rendered at build time (SSR)
-- The component is hydrated in the browser when the `<is-land>` becomes visible
+#### Props
 
-> **Note:** The `on:*` attribute prefix is changed to `land-on:*` to avoid conflicts with JSX syntax.
+| Prop        | Type                              | Description                                                                             |
+| ----------- | --------------------------------- | --------------------------------------------------------------------------------------- |
+| `component` | `HydratableComponent`             | Component wrapped with `hydratable()` in its `*.hydrate.jsx` file.                      |
+| `on`        | `string` (default: `interaction`) | is-land initialization trigger. Rendered as the boolean attribute `land-on:<on>`.       |
+| ...rest     | any                               | Serialized as `props` on `<is-land>` and forwarded to the component's SSR render as-is. |
 
-### `<is-land>` Attributes
+For parameterized triggers such as `on:media("(min-width: ...)")`, use the raw `<is-land>` element directly; the injected setup script still handles it.
 
-| Attribute   | Description                                                                                                                      |
-| ----------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `type`      | Hydration runtime. Set to `"preact"`.                                                                                            |
-| `import`    | Path to the hydration script (e.g., `./component.hydrate.js`).                                                                   |
-| `props`     | JSON-stringified props to pass to the component.                                                                                 |
-| `land-on:*` | [Initialization conditions](https://github.com/11ty/is-land?tab=readme-ov-file#usage) (e.g., `land-on:visible`, `land-on:idle`). |
+### Backward compatibility
+
+The raw `<is-land>` element remains fully supported — this plugin's script injection is unchanged. `<Island>` is a strict addition; existing partial hydration code continues to work.
 
 ## Requirements
 
+- Node.js 20 or higher
 - Eleventy 3.0 or higher
+- Preact 10 or higher
 
 ## License
 

--- a/packages/eleventy-plugin-preact-island/index.d.ts
+++ b/packages/eleventy-plugin-preact-island/index.d.ts
@@ -1,4 +1,5 @@
 import type { UserConfig } from "@11ty/eleventy";
+import type { HydrateModuleResolver } from "./resolver.js";
 
 export interface PluginOptions {
   /**
@@ -6,6 +7,13 @@ export interface PluginOptions {
    * If not specified, the latest version will be used.
    */
   preactVersion?: string;
+  /**
+   * Convert an SSR-side hydrate module URL (e.g. `import.meta.url` inside a
+   * `*.hydrate.jsx` file) into the browser URL where the compiled bundle is
+   * served. Defaults to `createHydrateModuleResolver()` which assumes `src/**`
+   * sources served under `/`.
+   */
+  resolveHydrateUrl?: HydrateModuleResolver;
 }
 
 /**

--- a/packages/eleventy-plugin-preact-island/index.mjs
+++ b/packages/eleventy-plugin-preact-island/index.mjs
@@ -1,10 +1,17 @@
 import url from "node:url";
+import { _setHydrateModuleResolver } from "./island.mjs";
+import { createHydrateModuleResolver } from "./resolver.mjs";
 
 /**
  * Eleventy plugin for Preact partial hydration with is-land
  * @param {import("@11ty/eleventy").UserConfig} eleventyConfig
  * @param {Object} pluginOptions
  * @param {string} [pluginOptions.preactVersion] - Preact version for esm.sh CDN
+ * @param {(moduleUrl: string) => string} [pluginOptions.resolveHydrateUrl] -
+ *   Convert an SSR-side hydrate module URL (e.g. `import.meta.url` inside a
+ *   `*.hydrate.jsx` file) into the browser URL of the compiled bundle. Defaults
+ *   to `createHydrateModuleResolver()` which assumes `src/**` sources served
+ *   under `/`.
  */
 export default function (eleventyConfig, pluginOptions = {}) {
   try {
@@ -13,7 +20,12 @@ export default function (eleventyConfig, pluginOptions = {}) {
     console.log(`[eleventy-plugin-preact-island] WARN: ${e.message}`);
   }
 
-  const { preactVersion = "" } = pluginOptions;
+  const {
+    preactVersion = "",
+    resolveHydrateUrl = createHydrateModuleResolver(),
+  } = pluginOptions;
+
+  _setHydrateModuleResolver(resolveHydrateUrl);
 
   // Copy is-land.js to output directory
   eleventyConfig.addPassthroughCopy({

--- a/packages/eleventy-plugin-preact-island/island.d.ts
+++ b/packages/eleventy-plugin-preact-island/island.d.ts
@@ -1,0 +1,40 @@
+import type { ComponentType, VNode } from "preact";
+
+export type HydratableComponent<P = Record<string, unknown>> =
+  ComponentType<P> & {
+    __hydrateModuleUrl: string;
+  };
+
+/**
+ * Attach the SSR-side module URL as metadata to a hydration component.
+ * Call in each `*.hydrate.jsx` file: `export default hydratable(Component, import.meta.url);`
+ */
+export function hydratable<P = Record<string, unknown>>(
+  Component: ComponentType<P>,
+  moduleUrl: string,
+): HydratableComponent<P>;
+
+export interface IslandProps<P = Record<string, unknown>> {
+  component: HydratableComponent<P>;
+  /**
+   * is-land initialization trigger. Common values: `"interaction"`, `"visible"`,
+   * `"idle"`. Rendered as the boolean attribute `land-on:<on>` on the underlying
+   * `<is-land>` element.
+   * @default "interaction"
+   */
+  on?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Wrap a Preact component for Partial Hydration via is-land. The extra props
+ * are forwarded both to the SSR render and to the hydrated client render.
+ */
+export function Island<P = Record<string, unknown>>(
+  props: IslandProps<P>,
+): VNode;
+
+/** @internal used by the plugin to install the URL resolver */
+export function _setHydrateModuleResolver(
+  resolver: (moduleUrl: string) => string,
+): void;

--- a/packages/eleventy-plugin-preact-island/island.mjs
+++ b/packages/eleventy-plugin-preact-island/island.mjs
@@ -56,6 +56,14 @@ export function Island({ component, on = "interaction", ...props }) {
       "Island: `component` prop must be a Preact component wrapped with `hydratable()`",
     );
   }
+  // Reject values that would produce a broken `land-on:*` attribute (whitespace,
+  // quotes, etc). is-land silently fails to fire on unknown trigger names, so
+  // catching typos at build time is the only signal the user gets.
+  if (typeof on !== "string" || !/^[A-Za-z0-9_-]+$/.test(on)) {
+    throw new TypeError(
+      `Island: \`on\` must match /^[A-Za-z0-9_-]+$/ (e.g. "interaction", "visible", "idle"), got: ${JSON.stringify(on)}`,
+    );
+  }
   const moduleUrl = component.__hydrateModuleUrl;
   if (typeof moduleUrl !== "string") {
     throw new Error(

--- a/packages/eleventy-plugin-preact-island/island.mjs
+++ b/packages/eleventy-plugin-preact-island/island.mjs
@@ -46,6 +46,11 @@ export function hydratable(Component, moduleUrl) {
  *   name (e.g. `"interaction"`, `"visible"`, `"idle"`).
  */
 export function Island({ component, on = "interaction", ...props }) {
+  // Drop children explicitly. Preact folds JSX children into props.children,
+  // and Island's contract is that SSR content comes from `component`; letting
+  // children fall through would leak Preact VNodes into the JSON-serialized
+  // `props` attribute on <is-land> and into the client hydration payload.
+  delete props.children;
   if (typeof component !== "function") {
     throw new TypeError(
       "Island: `component` prop must be a Preact component wrapped with `hydratable()`",
@@ -63,13 +68,22 @@ export function Island({ component, on = "interaction", ...props }) {
     );
   }
   const importUrl = currentResolver(moduleUrl);
+  let serializedProps;
+  try {
+    serializedProps = JSON.stringify(props);
+  } catch (cause) {
+    throw new Error(
+      `Island: failed to JSON.stringify props for hydration of ${component.name || "anonymous component"} (${importUrl}). Ensure all Island props are JSON-serializable.`,
+      { cause },
+    );
+  }
   return h(
     "is-land",
     {
       [`land-on:${on}`]: true,
       type: "preact",
       import: importUrl,
-      props: JSON.stringify(props),
+      props: serializedProps,
     },
     h(component, props),
   );

--- a/packages/eleventy-plugin-preact-island/island.mjs
+++ b/packages/eleventy-plugin-preact-island/island.mjs
@@ -1,0 +1,76 @@
+import { h } from "preact";
+
+let currentResolver = null;
+
+/**
+ * Install the hydrate module URL resolver. Called by the Eleventy plugin during
+ * config setup; not part of the public API.
+ * @internal
+ * @param {(moduleUrl: string) => string} resolver
+ */
+export function _setHydrateModuleResolver(resolver) {
+  currentResolver = resolver;
+}
+
+/**
+ * Attach the SSR-side module URL as metadata to a hydration component.
+ * Call this once in each `*.hydrate.jsx` file's default export.
+ *
+ * @template {import("preact").ComponentType<any>} C
+ * @param {C} Component
+ * @param {string} moduleUrl Usually `import.meta.url` from the hydrate file.
+ * @returns {C}
+ */
+export function hydratable(Component, moduleUrl) {
+  if (typeof Component !== "function") {
+    throw new TypeError("hydratable: `Component` must be a function");
+  }
+  if (typeof moduleUrl !== "string") {
+    throw new TypeError(
+      "hydratable: `moduleUrl` must be a string (usually `import.meta.url`)",
+    );
+  }
+  Component.__hydrateModuleUrl = moduleUrl;
+  return Component;
+}
+
+/**
+ * Wrap a Preact component for Partial Hydration via is-land. The SSR output is
+ * the component rendered with the same `props`, wrapped in `<is-land>` with the
+ * hydration import URL derived from the injected resolver.
+ *
+ * @param {Object} attrs
+ * @param {import("preact").ComponentType<any>} attrs.component - Component
+ *   wrapped with `hydratable()` in its `*.hydrate.jsx` file.
+ * @param {string} [attrs.on="interaction"] - is-land initialization trigger
+ *   name (e.g. `"interaction"`, `"visible"`, `"idle"`).
+ */
+export function Island({ component, on = "interaction", ...props }) {
+  if (typeof component !== "function") {
+    throw new TypeError(
+      "Island: `component` prop must be a Preact component wrapped with `hydratable()`",
+    );
+  }
+  const moduleUrl = component.__hydrateModuleUrl;
+  if (typeof moduleUrl !== "string") {
+    throw new Error(
+      "Island: `component` is not marked as hydratable. Wrap the default export of your *.hydrate.jsx file with `hydratable(Component, import.meta.url)`.",
+    );
+  }
+  if (typeof currentResolver !== "function") {
+    throw new Error(
+      "Island: no hydrate module URL resolver is configured. Ensure `@tuqulore-inc/eleventy-plugin-preact-island` is registered via `eleventyConfig.addPlugin`.",
+    );
+  }
+  const importUrl = currentResolver(moduleUrl);
+  return h(
+    "is-land",
+    {
+      [`land-on:${on}`]: true,
+      type: "preact",
+      import: importUrl,
+      props: JSON.stringify(props),
+    },
+    h(component, props),
+  );
+}

--- a/packages/eleventy-plugin-preact-island/island.test.mjs
+++ b/packages/eleventy-plugin-preact-island/island.test.mjs
@@ -1,0 +1,104 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert";
+import { h } from "preact";
+import { render } from "preact-render-to-string";
+import { Island, hydratable, _setHydrateModuleResolver } from "./island.mjs";
+
+describe("hydratable", () => {
+  it("Component に __hydrateModuleUrl を付与して同じ関数を返す", () => {
+    const Comp = () => null;
+    const returned = hydratable(Comp, "file:///proj/src/foo.hydrate.jsx");
+    assert.strictEqual(returned, Comp);
+    assert.strictEqual(
+      Comp.__hydrateModuleUrl,
+      "file:///proj/src/foo.hydrate.jsx",
+    );
+  });
+
+  it("Component が関数でない場合は TypeError", () => {
+    assert.throws(() => hydratable(null, "file:///x"), TypeError);
+    assert.throws(() => hydratable("Comp", "file:///x"), TypeError);
+  });
+
+  it("moduleUrl が文字列でない場合は TypeError", () => {
+    assert.throws(() => hydratable(() => null, undefined), TypeError);
+    assert.throws(() => hydratable(() => null, 123), TypeError);
+  });
+});
+
+describe("Island", () => {
+  beforeEach(() => {
+    // 各テストで resolver をリセットし、テスト間の状態漏れを防ぐ
+    _setHydrateModuleResolver(null);
+  });
+
+  it("hydratable 済み component を <is-land> でラップし、resolver 経由の import URL と JSON props を出力する", () => {
+    const receivedUrls = [];
+    _setHydrateModuleResolver((moduleUrl) => {
+      receivedUrls.push(moduleUrl);
+      return "/foo.hydrate.js";
+    });
+    const Foo = hydratable(function Foo(props) {
+      return h("span", null, props.name);
+    }, "file:///proj/src/foo.hydrate.jsx");
+
+    const html = render(
+      h(Island, { component: Foo, on: "visible", name: "alice" }),
+    );
+
+    assert.deepStrictEqual(receivedUrls, ["file:///proj/src/foo.hydrate.jsx"]);
+    assert.match(html, /^<is-land/);
+    assert.match(html, /land-on:visible/);
+    assert.match(html, /type="preact"/);
+    assert.match(html, /import="\/foo\.hydrate\.js"/);
+    // JSON.stringify({ name: "alice" }) が HTML エスケープされて属性値に入る
+    assert.match(html, /props="\{&quot;name&quot;:&quot;alice&quot;\}"/);
+    // SSR 内容として component が同じ props でレンダリングされている
+    assert.match(html, /<span>alice<\/span>/);
+    assert.match(html, /<\/is-land>$/);
+  });
+
+  it("on prop のデフォルトは interaction", () => {
+    _setHydrateModuleResolver(() => "/x.hydrate.js");
+    const X = hydratable(() => null, "file:///proj/src/x.hydrate.jsx");
+    const html = render(h(Island, { component: X }));
+    assert.match(html, /land-on:interaction/);
+  });
+
+  it("component が渡されていない (または関数でない) 場合は TypeError", () => {
+    _setHydrateModuleResolver(() => "/x.hydrate.js");
+    assert.throws(
+      () => render(h(Island, { component: "not-a-fn" })),
+      TypeError,
+    );
+  });
+
+  it("component が hydratable でラップされていない場合は明示エラー", () => {
+    _setHydrateModuleResolver(() => "/x.hydrate.js");
+    const Bare = () => null;
+    assert.throws(
+      () => render(h(Island, { component: Bare })),
+      /not marked as hydratable/,
+    );
+  });
+
+  it("resolver が未設定の場合は明示エラー", () => {
+    const X = hydratable(() => null, "file:///proj/src/x.hydrate.jsx");
+    assert.throws(
+      () => render(h(Island, { component: X })),
+      /no hydrate module URL resolver is configured/,
+    );
+  });
+
+  it("children を渡しても component の SSR 出力が優先される (呼び出し側は component だけ渡せば済む)", () => {
+    _setHydrateModuleResolver(() => "/x.hydrate.js");
+    const X = hydratable(function X(props) {
+      return h("i", null, `x-${props.tag}`);
+    }, "file:///proj/src/x.hydrate.jsx");
+    const html = render(
+      h(Island, { component: X, tag: "auto" }, h("b", null, "ignored")),
+    );
+    assert.match(html, /<i>x-auto<\/i>/);
+    assert.doesNotMatch(html, /<b>ignored<\/b>/);
+  });
+});

--- a/packages/eleventy-plugin-preact-island/island.test.mjs
+++ b/packages/eleventy-plugin-preact-island/island.test.mjs
@@ -101,4 +101,46 @@ describe("Island", () => {
     assert.match(html, /<i>x-auto<\/i>/);
     assert.doesNotMatch(html, /<b>ignored<\/b>/);
   });
+
+  it("children は props シリアライズにもコンポーネント SSR にも漏れない", () => {
+    _setHydrateModuleResolver(() => "/x.hydrate.js");
+    const receivedProps = [];
+    const X = hydratable(function X(props) {
+      receivedProps.push(props);
+      return h("i", null, `x-${props.tag}`);
+    }, "file:///proj/src/x.hydrate.jsx");
+
+    const html = render(
+      h(Island, { component: X, tag: "auto" }, h("b", null, "ignored")),
+    );
+
+    // <is-land props="..."> 属性に children/VNode が混入していないことを確認
+    // (props 属性値は tag のみで完結)
+    assert.match(html, /props="\{&quot;tag&quot;:&quot;auto&quot;\}"/);
+    // component 側にも children は渡らない
+    assert.deepStrictEqual(receivedProps, [{ tag: "auto" }]);
+  });
+
+  it("JSON.stringify に失敗する props (循環参照など) は Island 文脈のエラーで包む", () => {
+    _setHydrateModuleResolver(() => "/x.hydrate.js");
+    const X = hydratable(function X() {
+      return null;
+    }, "file:///proj/src/x.hydrate.jsx");
+
+    const circular = {};
+    circular.self = circular;
+
+    assert.throws(
+      () => render(h(Island, { component: X, data: circular })),
+      (err) => {
+        assert.match(err.message, /Island: failed to JSON\.stringify props/);
+        assert.match(err.message, /\/x\.hydrate\.js/);
+        assert.ok(
+          err.cause instanceof TypeError,
+          "元の TypeError が cause に保持されている",
+        );
+        return true;
+      },
+    );
+  });
 });

--- a/packages/eleventy-plugin-preact-island/island.test.mjs
+++ b/packages/eleventy-plugin-preact-island/island.test.mjs
@@ -73,6 +73,19 @@ describe("Island", () => {
     );
   });
 
+  it("on に不正な値 (空白 / 空文字 / 非文字列) を渡すと TypeError", () => {
+    _setHydrateModuleResolver(() => "/x.hydrate.js");
+    const X = hydratable(() => null, "file:///proj/src/x.hydrate.jsx");
+    for (const on of ["foo bar", "", 'bad"quote', 123, null]) {
+      assert.throws(
+        () => render(h(Island, { component: X, on })),
+        (err) =>
+          err instanceof TypeError && /`on` must match/.test(err.message),
+        `on=${JSON.stringify(on)} が TypeError にならなかった`,
+      );
+    }
+  });
+
   it("component が hydratable でラップされていない場合は明示エラー", () => {
     _setHydrateModuleResolver(() => "/x.hydrate.js");
     const Bare = () => null;

--- a/packages/eleventy-plugin-preact-island/package.json
+++ b/packages/eleventy-plugin-preact-island/package.json
@@ -21,26 +21,42 @@
     ".": {
       "types": "./index.d.ts",
       "default": "./index.mjs"
+    },
+    "./island": {
+      "types": "./island.d.ts",
+      "default": "./island.mjs"
+    },
+    "./resolver": {
+      "types": "./resolver.d.ts",
+      "default": "./resolver.mjs"
     }
   },
   "main": "./index.mjs",
   "files": [
     "README.md",
     "index.d.ts",
-    "index.mjs"
+    "index.mjs",
+    "island.d.ts",
+    "island.mjs",
+    "resolver.d.ts",
+    "resolver.mjs"
   ],
   "scripts": {
-    "lint": "eslint --fix ."
+    "lint": "eslint --fix .",
+    "test": "node --test"
   },
   "dependencies": {
     "@11ty/is-land": "^5.0.0"
   },
   "devDependencies": {
     "@tuqulore-inc/eslint-config": "workspace:*",
-    "eslint": "^10.0.0"
+    "eslint": "^10.0.0",
+    "preact": "^10.26.4",
+    "preact-render-to-string": "^6.5.13"
   },
   "peerDependencies": {
-    "@11ty/eleventy": ">=3.0.0"
+    "@11ty/eleventy": ">=3.0.0",
+    "preact": ">=10.0.0"
   },
   "engines": {
     "node": ">=20"

--- a/packages/eleventy-plugin-preact-island/resolver.d.ts
+++ b/packages/eleventy-plugin-preact-island/resolver.d.ts
@@ -1,0 +1,23 @@
+export interface CreateHydrateModuleResolverOptions {
+  /**
+   * Input directory that matches the Eleventy input directory / esbuild `outbase`.
+   * @default "src"
+   */
+  srcDir?: string;
+  /**
+   * URL path prefix where the compiled hydrate bundles are served.
+   * @default "/"
+   */
+  urlPrefix?: string;
+}
+
+export type HydrateModuleResolver = (moduleUrl: string) => string;
+
+/**
+ * Create a resolver that converts an SSR-side hydrate module URL
+ * (e.g. `import.meta.url` inside `foo.hydrate.jsx`) into the browser URL
+ * where the compiled bundle will be served.
+ */
+export function createHydrateModuleResolver(
+  options?: CreateHydrateModuleResolverOptions,
+): HydrateModuleResolver;

--- a/packages/eleventy-plugin-preact-island/resolver.mjs
+++ b/packages/eleventy-plugin-preact-island/resolver.mjs
@@ -1,0 +1,67 @@
+/**
+ * Create a resolver that converts an SSR-side hydrate module URL
+ * (e.g. `import.meta.url` inside `foo.hydrate.jsx`) into the browser URL
+ * where the compiled bundle will be served.
+ *
+ * Convention (customizable via options):
+ *   `<srcDir>/<sub>.hydrate.{jsx,tsx,js,ts}` → `<urlPrefix><sub>.hydrate.js`
+ *
+ * @param {Object} [options]
+ * @param {string} [options.srcDir="src"] Input directory that matches the
+ *   Eleventy input directory / esbuild `outbase`.
+ * @param {string} [options.urlPrefix="/"] URL path prefix where the compiled
+ *   bundles are served.
+ * @returns {(moduleUrl: string) => string}
+ */
+export function createHydrateModuleResolver({
+  srcDir = "src",
+  urlPrefix = "/",
+} = {}) {
+  if (typeof srcDir !== "string" || srcDir.length === 0) {
+    throw new TypeError(
+      "createHydrateModuleResolver: `srcDir` must be a non-empty string",
+    );
+  }
+  if (typeof urlPrefix !== "string") {
+    throw new TypeError(
+      "createHydrateModuleResolver: `urlPrefix` must be a string",
+    );
+  }
+
+  const marker = `/${srcDir}/`;
+  const normalizedPrefix = normalizeUrlPrefix(urlPrefix);
+
+  return function resolveHydrateModuleUrl(moduleUrl) {
+    let pathname;
+    try {
+      pathname = decodeURIComponent(new URL(moduleUrl).pathname);
+    } catch {
+      throw new Error(
+        `[eleventy-plugin-preact-island] Invalid module URL: ${moduleUrl}`,
+      );
+    }
+
+    const idx = pathname.lastIndexOf(marker);
+    if (idx === -1) {
+      throw new Error(
+        `[eleventy-plugin-preact-island] Hydrate module must live under "${srcDir}/": ${pathname}`,
+      );
+    }
+
+    const rest = pathname.slice(idx + marker.length);
+    const match = rest.match(/^(.+)\.hydrate\.(?:jsx|tsx|js|ts)$/);
+    if (!match) {
+      throw new Error(
+        `[eleventy-plugin-preact-island] Hydrate module must end with .hydrate.{js,jsx,ts,tsx}: ${pathname}`,
+      );
+    }
+    return `${normalizedPrefix}${match[1]}.hydrate.js`;
+  };
+}
+
+function normalizeUrlPrefix(prefix) {
+  let p = prefix;
+  if (!p.startsWith("/")) p = `/${p}`;
+  if (!p.endsWith("/")) p = `${p}/`;
+  return p;
+}

--- a/packages/eleventy-plugin-preact-island/resolver.mjs
+++ b/packages/eleventy-plugin-preact-island/resolver.mjs
@@ -17,9 +17,9 @@ export function createHydrateModuleResolver({
   srcDir = "src",
   urlPrefix = "/",
 } = {}) {
-  if (typeof srcDir !== "string" || srcDir.length === 0) {
+  if (typeof srcDir !== "string") {
     throw new TypeError(
-      "createHydrateModuleResolver: `srcDir` must be a non-empty string",
+      "createHydrateModuleResolver: `srcDir` must be a string",
     );
   }
   if (typeof urlPrefix !== "string") {
@@ -28,13 +28,21 @@ export function createHydrateModuleResolver({
     );
   }
 
-  const marker = `/${srcDir}/`;
+  const normalizedSrcDir = srcDir.replace(/^\/+|\/+$/g, "");
+  if (normalizedSrcDir.length === 0) {
+    throw new TypeError(
+      "createHydrateModuleResolver: `srcDir` must contain at least one path segment",
+    );
+  }
+  const marker = `/${normalizedSrcDir}/`;
   const normalizedPrefix = normalizeUrlPrefix(urlPrefix);
 
   return function resolveHydrateModuleUrl(moduleUrl) {
     let pathname;
     try {
-      pathname = decodeURIComponent(new URL(moduleUrl).pathname);
+      // Keep the pathname URL-encoded so the resulting browser URL stays a
+      // valid module specifier (e.g. spaces remain `%20`, not literal spaces).
+      pathname = new URL(moduleUrl).pathname;
     } catch {
       throw new Error(
         `[eleventy-plugin-preact-island] Invalid module URL: ${moduleUrl}`,
@@ -44,7 +52,7 @@ export function createHydrateModuleResolver({
     const idx = pathname.lastIndexOf(marker);
     if (idx === -1) {
       throw new Error(
-        `[eleventy-plugin-preact-island] Hydrate module must live under "${srcDir}/": ${pathname}`,
+        `[eleventy-plugin-preact-island] Hydrate module must live under "${normalizedSrcDir}/": ${pathname}`,
       );
     }
 

--- a/packages/eleventy-plugin-preact-island/resolver.test.mjs
+++ b/packages/eleventy-plugin-preact-island/resolver.test.mjs
@@ -51,14 +51,28 @@ describe("createHydrateModuleResolver", () => {
         );
       }
     });
+
+    it("srcDir の前後スラッシュを正規化する", () => {
+      const cases = ["src", "/src", "src/", "/src/"];
+      for (const srcDir of cases) {
+        const resolve = createHydrateModuleResolver({ srcDir });
+        assert.strictEqual(
+          resolve("file:///proj/src/foo.hydrate.jsx"),
+          "/foo.hydrate.js",
+          `srcDir=${JSON.stringify(srcDir)} の正規化が不正`,
+        );
+      }
+    });
   });
 
   describe("URL 解釈", () => {
-    it("URL エンコードされたパス (空白など) を復元する", () => {
+    it("URL エンコードされたパス (空白など) はエンコード形のまま維持する", () => {
+      // browser の import() が specifier として直接使うため、literal space に
+      // decode してはならない
       const resolve = createHydrateModuleResolver();
       assert.strictEqual(
         resolve("file:///proj/src/with%20space/foo.hydrate.jsx"),
-        "/with space/foo.hydrate.js",
+        "/with%20space/foo.hydrate.js",
       );
     });
 

--- a/packages/eleventy-plugin-preact-island/resolver.test.mjs
+++ b/packages/eleventy-plugin-preact-island/resolver.test.mjs
@@ -1,0 +1,117 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { createHydrateModuleResolver } from "./resolver.mjs";
+
+describe("createHydrateModuleResolver", () => {
+  describe("デフォルト設定", () => {
+    it("srcDir=src, urlPrefix=/ で src/**/*.hydrate.jsx を /**/hydrate.js に変換する", () => {
+      const resolve = createHydrateModuleResolver();
+      assert.strictEqual(
+        resolve("file:///home/user/proj/src/foo/bar.hydrate.jsx"),
+        "/foo/bar.hydrate.js",
+      );
+    });
+
+    it(".jsx / .tsx / .js / .ts を全て受け付け .hydrate.js に統一する", () => {
+      const resolve = createHydrateModuleResolver();
+      for (const ext of ["jsx", "tsx", "js", "ts"]) {
+        assert.strictEqual(
+          resolve(`file:///proj/src/foo.hydrate.${ext}`),
+          "/foo.hydrate.js",
+        );
+      }
+    });
+  });
+
+  describe("カスタム srcDir / urlPrefix", () => {
+    it("カスタム srcDir に従う", () => {
+      const resolve = createHydrateModuleResolver({ srcDir: "content" });
+      assert.strictEqual(
+        resolve("file:///proj/content/foo.hydrate.jsx"),
+        "/foo.hydrate.js",
+      );
+    });
+
+    it("カスタム urlPrefix を先頭に付ける", () => {
+      const resolve = createHydrateModuleResolver({ urlPrefix: "/assets" });
+      assert.strictEqual(
+        resolve("file:///proj/src/foo.hydrate.jsx"),
+        "/assets/foo.hydrate.js",
+      );
+    });
+
+    it("urlPrefix の前後スラッシュを正規化する", () => {
+      const cases = ["assets", "/assets", "assets/", "/assets/"];
+      for (const urlPrefix of cases) {
+        const resolve = createHydrateModuleResolver({ urlPrefix });
+        assert.strictEqual(
+          resolve("file:///proj/src/foo.hydrate.jsx"),
+          "/assets/foo.hydrate.js",
+          `urlPrefix=${JSON.stringify(urlPrefix)} の正規化が不正`,
+        );
+      }
+    });
+  });
+
+  describe("URL 解釈", () => {
+    it("URL エンコードされたパス (空白など) を復元する", () => {
+      const resolve = createHydrateModuleResolver();
+      assert.strictEqual(
+        resolve("file:///proj/src/with%20space/foo.hydrate.jsx"),
+        "/with space/foo.hydrate.js",
+      );
+    });
+
+    it("経路の途中に src と紛らわしい名前 (src-review など) があっても最後の /src/ を採用する", () => {
+      const resolve = createHydrateModuleResolver();
+      assert.strictEqual(
+        resolve("file:///Users/x/src-review/src/foo.hydrate.jsx"),
+        "/foo.hydrate.js",
+      );
+    });
+  });
+
+  describe("エラー", () => {
+    it("srcDir 配下にないモジュールは判別可能なエラーで失敗する", () => {
+      const resolve = createHydrateModuleResolver();
+      assert.throws(
+        () => resolve("file:///proj/content/foo.hydrate.jsx"),
+        /must live under "src\/"/,
+      );
+    });
+
+    it(".hydrate.{js,jsx,ts,tsx} 以外はエラーで失敗する", () => {
+      const resolve = createHydrateModuleResolver();
+      assert.throws(
+        () => resolve("file:///proj/src/foo.jsx"),
+        /must end with \.hydrate/,
+      );
+    });
+
+    it("URL として不正な値はエラーで失敗する", () => {
+      const resolve = createHydrateModuleResolver();
+      assert.throws(() => resolve("not-a-url"), /Invalid module URL/);
+    });
+
+    it("srcDir が空文字列だと factory 呼び出しの時点で TypeError", () => {
+      assert.throws(
+        () => createHydrateModuleResolver({ srcDir: "" }),
+        TypeError,
+      );
+    });
+
+    it("srcDir が非文字列だと factory 呼び出しの時点で TypeError", () => {
+      assert.throws(
+        () => createHydrateModuleResolver({ srcDir: 123 }),
+        TypeError,
+      );
+    });
+
+    it("urlPrefix が非文字列だと factory 呼び出しの時点で TypeError", () => {
+      assert.throws(
+        () => createHydrateModuleResolver({ urlPrefix: 123 }),
+        TypeError,
+      );
+    });
+  });
+});

--- a/packages/eleventy-plugin-preact/README.md
+++ b/packages/eleventy-plugin-preact/README.md
@@ -45,6 +45,30 @@ eleventyConfig.addPlugin(preact, {
 });
 ```
 
+### `outbase`
+
+- Type: `string`
+- Default: `"src"`
+
+esbuild `outbase` used when bundling hydration entry points. Should match the directory prefix you want stripped from output paths (usually the Eleventy input directory).
+
+### `outdir`
+
+- Type: `string`
+- Default: `"dist"`
+
+esbuild `outdir` used when bundling hydration entry points. Usually the Eleventy output directory.
+
+```javascript
+eleventyConfig.addPlugin(preact, {
+  hydrateGlob: "./content/**/*.hydrate.jsx",
+  outbase: "content",
+  outdir: "_site",
+});
+```
+
+When you customize these, remember to also pass a matching `resolveHydrateUrl` to `@tuqulore-inc/eleventy-plugin-preact-island` so the browser URLs stay in sync.
+
 ## Eleventy Data Access
 
 This plugin provides a singleton object for accessing Eleventy data from any template or component during SSR, without prop drilling.
@@ -73,7 +97,7 @@ import { eleventy } from "@tuqulore-inc/eleventy-plugin-preact/eleventy";
 ### Important Notes
 
 - The `eleventy` singleton is only available during SSR. Accessing it outside of SSR context will throw an error.
-- For hydrated components (`<is-land>`), continue to pass props via `props={JSON.stringify(...)}` since client-side hydration cannot access server-side data.
+- For hydrated components, use `<Island>` from `@tuqulore-inc/eleventy-plugin-preact-island/island`, which forwards the passed props to both the SSR render and the client hydration; the `eleventy` singleton itself is not available on the client.
 
 ## With Partial Hydration
 

--- a/packages/eleventy-plugin-preact/index.d.ts
+++ b/packages/eleventy-plugin-preact/index.d.ts
@@ -7,6 +7,18 @@ export interface PluginOptions {
    * Example: "./src/**\/*.hydrate.jsx"
    */
   hydrateGlob?: string;
+  /**
+   * esbuild `outbase` used when bundling hydration entry points.
+   * Should match the directory prefix you want stripped from output paths
+   * (usually the Eleventy input directory).
+   * @default "src"
+   */
+  outbase?: string;
+  /**
+   * esbuild `outdir` used when bundling hydration entry points.
+   * @default "dist"
+   */
+  outdir?: string;
 }
 
 /**

--- a/packages/eleventy-plugin-preact/index.mjs
+++ b/packages/eleventy-plugin-preact/index.mjs
@@ -20,6 +20,8 @@ module.register(
  * @param {import("@11ty/eleventy").UserConfig} eleventyConfig
  * @param {Object} pluginOptions
  * @param {string} [pluginOptions.hydrateGlob] - Glob pattern for hydration entry points
+ * @param {string} [pluginOptions.outbase="src"] - esbuild `outbase` for hydration bundles
+ * @param {string} [pluginOptions.outdir="dist"] - esbuild `outdir` for hydration bundles
  */
 export default function (eleventyConfig, pluginOptions = {}) {
   try {
@@ -28,7 +30,7 @@ export default function (eleventyConfig, pluginOptions = {}) {
     console.log(`[eleventy-plugin-preact] WARN: ${e.message}`);
   }
 
-  const { hydrateGlob } = pluginOptions;
+  const { hydrateGlob, outbase = "src", outdir = "dist" } = pluginOptions;
 
   // Add JSX and MDX as template formats
   eleventyConfig.addTemplateFormats(["jsx", "mdx"]);
@@ -64,8 +66,8 @@ export default function (eleventyConfig, pluginOptions = {}) {
         format: "esm",
         jsx: "automatic",
         jsxImportSource: "preact",
-        outbase: "src",
-        outdir: "dist",
+        outbase,
+        outdir,
       };
       const ctx = await esbuild.context(options);
       if (runMode === "build") {

--- a/packages/eleventy-preset/README.md
+++ b/packages/eleventy-preset/README.md
@@ -68,6 +68,7 @@ This preset supports JSX and MDX as template languages via `@tuqulore-inc/eleven
 ### Basic MDX Example
 
 ```mdx
+import { Island } from "@tuqulore-inc/eleventy-preset/island";
 import Clicker from "./clicker.hydrate.jsx";
 
 export const data = {
@@ -79,9 +80,7 @@ export const data = {
 
 Content goes here.
 
-<is-land land-on:interaction type="preact" import="./clicker.hydrate.js">
-  <Clicker />
-</is-land>
+<Island component={Clicker} on="interaction" />
 ```
 
 ## Data Export
@@ -174,7 +173,7 @@ import { eleventy } from "@tuqulore-inc/eleventy-preset/eleventy";
 ### Important Notes
 
 - The `eleventy` singleton is only available during SSR (server-side rendering)
-- For hydrated components (`<is-land>`), continue to pass props via `props={JSON.stringify(...)}` since client-side hydration cannot access server-side data
+- For hydrated components, use `<Island>` which automatically forwards the passed props to both the SSR render and the client hydration; the raw `eleventy` singleton is not available on the client
 
 ### Available Data
 
@@ -246,17 +245,18 @@ import Footer from "./partials/footer.mdx";
 
 ## Partial Hydration
 
-This preset supports partial hydration using `@tuqulore-inc/eleventy-plugin-preact-island` and `<is-land>`.
+This preset supports partial hydration using `@tuqulore-inc/eleventy-plugin-preact-island`. Author hydration components under `src/**/*.hydrate.jsx`, mark the default export with `hydratable()`, and render them from any JSX/MDX template through the `<Island>` wrapper.
 
 ### Creating a Hydrated Component
 
-Name your component with the `.hydrate.jsx` suffix:
+Name your component with the `.hydrate.jsx` suffix and mark the default export with `hydratable`:
 
 ```jsx
 // src/clicker.hydrate.jsx
+import { hydratable } from "@tuqulore-inc/eleventy-preset/island";
 import { useState } from "preact/hooks";
 
-export default function Clicker() {
+function Clicker() {
   const [counter, setCounter] = useState(0);
 
   return (
@@ -266,49 +266,48 @@ export default function Clicker() {
     </div>
   );
 }
+
+export default hydratable(Clicker, import.meta.url);
 ```
+
+`hydratable(Component, import.meta.url)` attaches the SSR-side module URL as metadata; the preset's URL resolver converts it to the browser URL (`src/foo.hydrate.jsx` → `/foo.hydrate.js`).
 
 ### Using in MDX
 
-Import the component and wrap it with `<is-land>`:
+Import the component and wrap with `<Island>`. Extra props are forwarded to both the SSR render and the client hydration:
 
 ```mdx
+import { Island } from "@tuqulore-inc/eleventy-preset/island";
 import Clicker from "./clicker.hydrate.jsx";
 
-<is-land land-on:interaction type="preact" import="./clicker.hydrate.js">
-  <Clicker />
-</is-land>
+<Island component={Clicker} on="interaction" />
 ```
 
-### Passing Props
-
-For hydrated components that need props, serialize them with `JSON.stringify`:
-
 ```mdx
+import { Island } from "@tuqulore-inc/eleventy-preset/island";
 import Navigation from "./partials/header/navigation.hydrate.jsx";
 
-<is-land
-land-on:interaction
-type="preact"
-import="/\_includes/partials/header/navigation.hydrate.js"
-props={JSON.stringify({ nav: props.nav, class: "hidden md:block" })}
-
->
-
-  <Navigation nav={props.nav} class="hidden md:block" />
-</is-land>
+<Island
+  component={Navigation}
+  on="interaction"
+  class="hidden md:block"
+  nav={props.nav}
+/>
 ```
 
 ### Hydration Triggers
 
-| Attribute             | Description                                      |
-| --------------------- | ------------------------------------------------ |
-| `land-on:interaction` | Hydrate on user interaction (click, focus, etc.) |
-| `land-on:visible`     | Hydrate when element becomes visible             |
-| `land-on:idle`        | Hydrate when browser is idle                     |
-| `land-on:media`       | Hydrate based on media query                     |
+The `on` prop maps to the `land-on:<value>` attribute on the underlying `<is-land>`:
 
-See [@tuqulore-inc/eleventy-plugin-preact-island](../eleventy-plugin-preact-island/README.md) for more details.
+| `on` value    | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `interaction` | Hydrate on user interaction (click, focus, etc.) |
+| `visible`     | Hydrate when element becomes visible             |
+| `idle`        | Hydrate when browser is idle                     |
+
+For parameterized triggers such as `on:media("(min-width: ...)")`, drop down to the raw `<is-land>` element (still supported); the injected setup script keeps working.
+
+See [@tuqulore-inc/eleventy-plugin-preact-island](../eleventy-plugin-preact-island/README.md) for the underlying plugin, including how to swap the URL resolver when using it outside this preset.
 
 ## Requirements
 

--- a/packages/eleventy-preset/index.mjs
+++ b/packages/eleventy-preset/index.mjs
@@ -13,12 +13,15 @@ const OUT_DIR = "dist";
 const URL_PREFIX = "/";
 
 /**
- * Optimize images in src directory and output to dist
+ * Optimize images under SRC_DIR and output the same tree under OUT_DIR
  */
 const optimizeImages = async () => {
-  const images = await fg(["src/**/*.{jpeg,jpg,png,webp,gif,tiff,avif,svg}"], {
-    ignore: ["dist", "**/node_modules", "src/public"],
-  });
+  const images = await fg(
+    [`${SRC_DIR}/**/*.{jpeg,jpg,png,webp,gif,tiff,avif,svg}`],
+    {
+      ignore: [OUT_DIR, "**/node_modules", `${SRC_DIR}/public`],
+    },
+  );
   for (const image of images) {
     await Image(image, {
       filenameFormat: () => path.basename(image),
@@ -26,7 +29,9 @@ const optimizeImages = async () => {
       sharpOptions: {
         animated: true,
       },
-      outputDir: path.dirname(image).replace(/^src/, "dist"),
+      outputDir: path
+        .dirname(image)
+        .replace(new RegExp(`^${SRC_DIR}`), OUT_DIR),
     });
   }
 };
@@ -61,12 +66,12 @@ export default function preset(extend = () => {}) {
 
     // PostCSS processing
     eleventyConfig.addPlugin(postcss, {
-      contentGlob: ["src/**/*.{md,mdx,jsx}"],
+      contentGlob: [`${SRC_DIR}/**/*.{md,mdx,jsx}`],
     });
 
     // Watch generated CSS for dev server reload
     eleventyConfig.setServerOptions({
-      watch: ["dist/**/*.css"],
+      watch: [`${OUT_DIR}/**/*.css`],
     });
 
     // Markdown settings
@@ -74,8 +79,8 @@ export default function preset(extend = () => {}) {
       md.set({ breaks: true, linkify: true }),
     );
 
-    // Copy static assets from src/public to root
-    eleventyConfig.addPassthroughCopy({ "src/public/**": "/" });
+    // Copy static assets from SRC_DIR/public to root
+    eleventyConfig.addPassthroughCopy({ [`${SRC_DIR}/public/**`]: "/" });
 
     // Optimize images before build
     eleventyConfig.on("eleventy.before", optimizeImages);

--- a/packages/eleventy-preset/index.mjs
+++ b/packages/eleventy-preset/index.mjs
@@ -2,8 +2,15 @@ import Image from "@11ty/eleventy-img";
 import postcss from "@tuqulore-inc/eleventy-plugin-postcss";
 import preact from "@tuqulore-inc/eleventy-plugin-preact";
 import preactIsland from "@tuqulore-inc/eleventy-plugin-preact-island";
+import { createHydrateModuleResolver } from "@tuqulore-inc/eleventy-plugin-preact-island/resolver";
 import fg from "fast-glob";
 import path from "node:path";
+
+// This preset's directory / URL convention. Both the SSR bundler and the Island
+// URL resolver are wired from these values so the two stay in sync.
+const SRC_DIR = "src";
+const OUT_DIR = "dist";
+const URL_PREFIX = "/";
 
 /**
  * Optimize images in src directory and output to dist
@@ -34,16 +41,23 @@ export default function preset(extend = () => {}) {
     eleventyConfig.versionCheck(">=3.0");
 
     // Input & Output Directories
-    eleventyConfig.setInputDirectory("src");
-    eleventyConfig.setOutputDirectory("dist");
+    eleventyConfig.setInputDirectory(SRC_DIR);
+    eleventyConfig.setOutputDirectory(OUT_DIR);
 
     // Preact SSR + hydration
     eleventyConfig.addPlugin(preact, {
-      hydrateGlob: "./src/**/*.hydrate.jsx",
+      hydrateGlob: `./${SRC_DIR}/**/*.hydrate.jsx`,
+      outbase: SRC_DIR,
+      outdir: OUT_DIR,
     });
 
     // Preact partial hydration with is-land
-    eleventyConfig.addPlugin(preactIsland);
+    eleventyConfig.addPlugin(preactIsland, {
+      resolveHydrateUrl: createHydrateModuleResolver({
+        srcDir: SRC_DIR,
+        urlPrefix: URL_PREFIX,
+      }),
+    });
 
     // PostCSS processing
     eleventyConfig.addPlugin(postcss, {

--- a/packages/eleventy-preset/island.d.ts
+++ b/packages/eleventy-preset/island.d.ts
@@ -1,0 +1,6 @@
+export {
+  Island,
+  hydratable,
+  type HydratableComponent,
+  type IslandProps,
+} from "@tuqulore-inc/eleventy-plugin-preact-island/island";

--- a/packages/eleventy-preset/island.mjs
+++ b/packages/eleventy-preset/island.mjs
@@ -1,0 +1,4 @@
+export {
+  Island,
+  hydratable,
+} from "@tuqulore-inc/eleventy-plugin-preact-island/island";

--- a/packages/eleventy-preset/package.json
+++ b/packages/eleventy-preset/package.json
@@ -24,6 +24,10 @@
     "./eleventy": {
       "types": "./eleventy.d.ts",
       "default": "./eleventy.mjs"
+    },
+    "./island": {
+      "types": "./island.d.ts",
+      "default": "./island.mjs"
     }
   },
   "main": "./index.mjs",
@@ -32,7 +36,9 @@
     "index.d.ts",
     "index.mjs",
     "eleventy.d.ts",
-    "eleventy.mjs"
+    "eleventy.mjs",
+    "island.d.ts",
+    "island.mjs"
   ],
   "scripts": {
     "lint": "eslint --fix ."

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,12 @@ importers:
       eslint:
         specifier: ^10.0.0
         version: 10.6.0
+      preact:
+        specifier: ^10.26.4
+        version: 10.29.4
+      preact-render-to-string:
+        specifier: ^6.5.13
+        version: 6.7.0(preact@10.29.4)
 
   packages/eleventy-preset:
     dependencies:


### PR DESCRIPTION
## Summary

- `<Island component={X} on="interaction" {...props} />` 一発で `<is-land>` / `type="preact"` / `import` URL / `JSON.stringify(props)` / SSR 子要素の重複記述を全て解消。既存の生 `<is-land>` 記法との後方互換は維持。
- hydrate 対象は `hydratable(Component, import.meta.url)` で明示。注入可能な resolver 経由でブラウザ URL を導出するため、当リポジトリの規約に閉じず、preset を使わない Eleventy 環境でも `resolveHydrateUrl` を差し替えれば動く。
- `eleventy-plugin-preact` にも `outbase` / `outdir` オプションを追加し、両プラグインを単体で使うときに規約を差し替えられるようにした。`eleventy-preset` は規約 (`src` / `dist` / `/`) を集約して両プラグインを配線。

## 呼び出し側の Before / After

Before (`packages/create-eleventy/templates/default/src/__includes/partials/header.mdx`):

```jsx
<is-land
  land-on:interaction
  type="preact"
  import="/_includes/partials/header/desktop.hydrate.js"
  props={JSON.stringify({ class: "hidden md:block", nav: eleventy.nav })}
>
  <Desktop class="hidden md:block" nav={eleventy.nav} />
</is-land>
```

After:

```jsx
<Island
  component={Desktop}
  on="interaction"
  class="hidden md:block"
  nav={eleventy.nav}
/>
```

`desktop.hydrate.jsx` 側は `export default hydratable(Desktop, import.meta.url);` を追記するだけ。

## 変更ファイル

- 新規: \`packages/eleventy-plugin-preact-island/{island,resolver}.{mjs,d.ts,test.mjs}\`, \`packages/eleventy-preset/island.{mjs,d.ts}\`
- 更新: 3 プラグイン / preset の \`index.mjs\` / \`.d.ts\` / \`package.json\` / \`README.md\`、テンプレート 5 ファイル (Island 記法へ置換)

## Test plan

- [x] \`pnpm -r lint\`
- [x] \`pnpm -r test\` (island.test.mjs / resolver.test.mjs の 22 テスト新規追加。テンプレート E2E \`templates.test.mjs\` で pack → scaffold → install → build が緑)
- [x] 手動テスト (CONTRIBUTING.md の scaffold スクリプト → \`pnpm dev\` で Clicker / Desktop nav / Mobile nav の hydrate 動作をブラウザ確認)
- [ ] preset を使わず \`eleventy-plugin-preact-island\` 単体で \`resolveHydrateUrl\` を差し替えるユースケースの実際の interop 動作

closes #851

🤖 Generated with [Claude Code](https://claude.com/claude-code)