### PR TITLE
fix(docs): pack tarball 選択 glob を preact / preact-island で誤マッチしないよう修正

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,8 @@ done
 # WORK を単独ワークスペース化して pnpm-workspace.yaml に overrides を書き出す。
 # - overrides は transitive にも効くので、テンプレートが直接依存していないプラグイン群も一括で差し替わる。
 # - file: は具体名を渡す必要があり glob (*.tgz) は解決されないため、pack で生成された tarball 名をシェル側で解決する。
+# - glob は SHORT の直後を [0-9] に固定する。preact / preact-island のように片方が
+#   他方の prefix になる名前で `${SHORT}-*` を使うと両 tarball にマッチしてしまうため。
 # - allowBuilds はリポジトリルート pnpm-workspace.yaml の設定を踏襲する。
 {
   echo "packages:"
@@ -100,7 +102,7 @@ done
   echo "overrides:"
   for NAME in "${PKGS[@]}"; do
     SHORT=${NAME/@tuqulore-inc\//tuqulore-inc-}
-    TARBALL=$(ls "$PACK/$SHORT"-*.tgz)
+    TARBALL=$(ls "$PACK/${SHORT}-"[0-9]*.tgz)
     echo "  \"$NAME\": \"file:$TARBALL\""
   done
   echo "allowBuilds:"


### PR DESCRIPTION
## Summary

CONTRIBUTING.md の手動テスト用 scaffold スクリプトのバグ修正です。

\`\`\`bash
TARBALL=$(ls "$PACK/$SHORT"-*.tgz)
\`\`\`

上記の glob は SHORT が \`tuqulore-inc-eleventy-plugin-preact\` のとき、`preact-<ver>.tgz` と `preact-island-<ver>.tgz` の両方にマッチしてしまい、\`TARBALL\` に 2 つのパスがスペース区切りで入り、その後の \`pnpm install\` が ENOENT で失敗します。

SHORT の直後を \`[0-9]\` に固定して version 部だけを glob 展開に流すことで、片方の名前が他方の prefix になっているケースでも意図した tarball 1 個だけを選ぶようにしました。

## Reproduce (fix 前)

リポジトリルートで CONTRIBUTING.md 記載のスクリプトをそのまま実行すると:

\`\`\`
ENOENT: no such file or directory, open
'/tmp/tmp.XXXX/tuqulore-inc-eleventy-plugin-preact-4.1.1-alpha.0.tgz
 /tmp/tmp.XXXX/tuqulore-inc-eleventy-plugin-preact-island-4.1.1-alpha.0.tgz'
\`\`\`

## Test plan

- [x] 修正後のスクリプトで scaffold + \`pnpm install\` + \`pnpm build\` が完走
- [x] 生成された \`pnpm-workspace.yaml\` の overrides に各パッケージが 1 tarball ずつ列挙される

🤖 Generated with [Claude Code](https://claude.com/claude-code)