### PR TITLE
refactor!: Island プラグインに client 責務を集約し規約ファースト API へ縮退

### DIFF
--- a/packages/create-eleventy/templates.test.mjs
+++ b/packages/create-eleventy/templates.test.mjs
@@ -190,6 +190,13 @@ describe("create-eleventy templates", { concurrency: true }, () => {
               );
             }
 
+            // ignore ルールの回帰検知: *.client.jsx が Eleventy テンプレートとして
+            // 処理されると dist/clicker.client/ のようなページが生成されてしまう。
+            assert.ok(
+              !fs.existsSync(path.join(projectDir, "dist", "clicker.client")),
+              "dist/clicker.client/ が生成されている (.client.* の Eleventy ignore が効いていない可能性)",
+            );
+
             const indexHtml = fs.readFileSync(
               path.join(projectDir, "dist", "index.html"),
               "utf8",

--- a/packages/create-eleventy/templates.test.mjs
+++ b/packages/create-eleventy/templates.test.mjs
@@ -170,6 +170,36 @@ describe("create-eleventy templates", { concurrency: true }, () => {
             fs.existsSync(path.join(projectDir, "dist", "index.html")),
             "build 後に dist/index.html が生成されていない",
           );
+
+          // default テンプレートは 3 つの *.client.jsx を持ち、Island プラグイン
+          // によって esbuild で bundle され、index.mdx から <Island component={Clicker}>
+          // として参照される。responsibility split と命名変更で URL 経路が壊れて
+          // も回帰検知できるよう、生成物の実在と HTML 内の import URL を検証する。
+          if (template === "default") {
+            // CLI が `__prefix` を `_prefix` にリネームするため、build 出力上は
+            // `_includes/**` に落ちる (index.mjs L84-89 を参照)。
+            const expectedBundles = [
+              "clicker.client.js",
+              "_includes/partials/header/desktop.client.js",
+              "_includes/partials/header/mobile.client.js",
+            ];
+            for (const rel of expectedBundles) {
+              assert.ok(
+                fs.existsSync(path.join(projectDir, "dist", rel)),
+                `build 後に dist/${rel} が生成されていない (esbuild bundle が動いていない可能性)`,
+              );
+            }
+
+            const indexHtml = fs.readFileSync(
+              path.join(projectDir, "dist", "index.html"),
+              "utf8",
+            );
+            assert.match(
+              indexHtml,
+              /<is-land[^>]*\bimport="\/clicker\.client\.js"/,
+              'dist/index.html に <is-land import="/clicker.client.js"> が含まれていない (Island の URL 解決経路が壊れている可能性)',
+            );
+          }
         },
       );
     });

--- a/packages/create-eleventy/templates/default/README.md
+++ b/packages/create-eleventy/templates/default/README.md
@@ -112,37 +112,49 @@ Eleventyテンプレートの参照先です。
 
 ## Partial Hydration
 
-JSXテンプレートの拡張子を `.hydrate.jsx` にすると、`dist/**/*.hydrate.jsx` にハイドレーション用のスクリプトが生成されます。
+JSXテンプレートの拡張子を `.client.jsx` にすると、その file は esbuild でバンドルされて `dist/**/*.client.js` に出力され、`<Island>` コンポーネントを通じて \<is-land> のクライアント側スクリプトとして読み込まれます。
 
-次の例では、Componentコンポーネントをハイドレーションしています。
+`clientComponent()` でマークしたコンポーネントを `<Island>` に渡すと、SSR 側の描画と、クライアント側のハイドレーションの両方に同じ props が流れます。
+
+```jsx
+// src/counter.client.jsx
+import { clientComponent } from "@tuqulore-inc/eleventy-preset/island";
+import { useState } from "preact/hooks";
+
+function Counter(props) {
+  const [n, setN] = useState(props.initial ?? 0);
+  return <button onClick={() => setN(n + 1)}>{n}</button>;
+}
+
+export default clientComponent(Counter, import.meta.url);
+```
 
 ```mdx
-import Component from "./component.hydrate.jsx"; // ./component.hydrate.jsxはJSXテンプレートとして使用できます
+// src/index.mdx
+import { Island } from "@tuqulore-inc/eleventy-preset/island";
+import Counter from "./counter.client.jsx";
 
-{/* ./component.hydrate.jsxはブラウザーでの読み込み時に描画されます */}
-<is-land land-on:visible type="preact" import="./component.hydrate.js" props='{ "someProp": "somePropValue" }'>
+<Island component={Counter} on="interaction" initial={5} />
+```
 
-  <Component someProp="somePropValue" />{/* <Component />はビルド時に描画されます */}
+上の例では、`<Island>` が次のような \<is-land> 要素を SSR 出力します。
+
+```html
+<is-land
+  land-on:interaction
+  type="preact"
+  import="/counter.client.js"
+  props='{"initial":5}'
+>
+  <button>5</button>
 </is-land>
 ```
 
+`on` prop は \<is-land> の初期化トリガー (`interaction` / `visible` / `idle`) に対応します。
+
 > [!NOTE]
 >
-> [\<is-land>](https://github.com/11ty/is-land?tab=readme-ov-file#usage)の初期化条件を指定する属性は、デフォルトでは`on:*`の書式で指定する必要がありますが、JSXの書式と競合するので`land-on:*`に変更しています。
-
-\<is-land>Webコンポーネントは`land-on:*`属性のほか、次の属性を受け付けます。
-
-### `type`属性
-
-ハイドレーションに使用するランタイム。`"preact"`を指定します。
-
-### `import`属性
-
-ハイドレーションに使用する`dist/**/*.hydrate.js`のパス。
-
-### `props`属性
-
-`dist/**/*.hydrate.js`に渡すプロパティ。オブジェクトを文字列化した値を指定します。通常、オブジェクトの文字列化にJSON.stringifyを使用することができます。
+> [\<is-land>](https://github.com/11ty/is-land?tab=readme-ov-file#usage)の初期化条件を指定する属性は、デフォルトでは `on:*` の書式で指定する必要がありますが、JSX の書式と競合するので `land-on:*` に変更しています。パラメータ付きトリガー (例: `on:media("(min-width: ...)")`) を使う場合は `<Island>` ではなく素の \<is-land> を直接書いてください。
 
 ## Docker
 

--- a/packages/create-eleventy/templates/default/README.md
+++ b/packages/create-eleventy/templates/default/README.md
@@ -112,7 +112,7 @@ Eleventyテンプレートの参照先です。
 
 ## Partial Hydration
 
-JSXテンプレートの拡張子を `.client.jsx` にすると、その file は esbuild でバンドルされて `dist/**/*.client.js` に出力され、`<Island>` コンポーネントを通じて \<is-land> のクライアント側スクリプトとして読み込まれます。
+`.client.{js,jsx,ts,tsx}` という拡張子のファイルを `src` 配下に置くだけで、設定不要でパーシャルハイドレーションが有効になります。そのファイルは esbuild でバンドルされて `dist/**/*.client.js` に出力され、`<Island>` コンポーネントを通じて \<is-land> のクライアント側スクリプトとして読み込まれます。
 
 `clientComponent()` でマークしたコンポーネントを `<Island>` に渡すと、SSR 側の描画と、クライアント側のハイドレーションの両方に同じ props が流れます。
 

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header.mdx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header.mdx
@@ -1,7 +1,7 @@
 import { Island } from "@tuqulore-inc/eleventy-preset/island";
 import { eleventy } from "@tuqulore-inc/eleventy-preset/eleventy";
-import Desktop from "./header/desktop.hydrate.jsx";
-import Mobile from "./header/mobile.hydrate.jsx";
+import Desktop from "./header/desktop.client.jsx";
+import Mobile from "./header/mobile.client.jsx";
 
 <header class="sticky top-0 mb-8 bg-white shadow">
   <div class="mx-auto flex h-16 max-w-6xl items-center justify-between gap-4 px-4 md:justify-start">

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
@@ -1,4 +1,4 @@
-import { hydratable } from "@tuqulore-inc/eleventy-preset/island";
+import { clientComponent } from "@tuqulore-inc/eleventy-preset/island";
 import { useState, useRef, useEffect } from "preact/hooks";
 import slugify from "slugify";
 import { twMerge } from "tailwind-merge";
@@ -81,4 +81,4 @@ function Desktop(props) {
   );
 }
 
-export default hydratable(Desktop, import.meta.url);
+export default clientComponent(Desktop, import.meta.url);

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
@@ -1,4 +1,4 @@
-import { hydratable } from "@tuqulore-inc/eleventy-preset/island";
+import { clientComponent } from "@tuqulore-inc/eleventy-preset/island";
 import { useState } from "preact/hooks";
 import { twMerge } from "tailwind-merge";
 
@@ -76,4 +76,4 @@ function Mobile(props) {
   );
 }
 
-export default hydratable(Mobile, import.meta.url);
+export default clientComponent(Mobile, import.meta.url);

--- a/packages/create-eleventy/templates/default/src/clicker.client.jsx
+++ b/packages/create-eleventy/templates/default/src/clicker.client.jsx
@@ -1,4 +1,4 @@
-import { hydratable } from "@tuqulore-inc/eleventy-preset/island";
+import { clientComponent } from "@tuqulore-inc/eleventy-preset/island";
 import { useState } from "preact/hooks";
 
 function Clicker() {
@@ -14,4 +14,4 @@ function Clicker() {
   );
 }
 
-export default hydratable(Clicker, import.meta.url);
+export default clientComponent(Clicker, import.meta.url);

--- a/packages/create-eleventy/templates/default/src/index.mdx
+++ b/packages/create-eleventy/templates/default/src/index.mdx
@@ -1,5 +1,5 @@
 import { Island } from "@tuqulore-inc/eleventy-preset/island";
-import Clicker from "./clicker.hydrate.jsx";
+import Clicker from "./clicker.client.jsx";
 
 export const data = {
   layout: "post",

--- a/packages/eleventy-plugin-preact-island/README.md
+++ b/packages/eleventy-plugin-preact-island/README.md
@@ -9,7 +9,7 @@ An Island is the SSR-rendered HTML with client-side JavaScript layered on top; t
 3. Injects the browser-side [`@11ty/is-land`](https://github.com/11ty/is-land) + Preact setup into every HTML page.
 4. Provides an `<Island>` wrapper that renders SSR content and emits the matching `<is-land>` element with the correct `import` URL for hydration.
 
-All four are wired from a single source of truth (`srcDir` / `outDir` / `urlPrefix`), so the bundle output layout and the hydration import URL cannot drift.
+The bundle output layout (`srcDir` / `outDir`) and the hydration import URL are wired from the same options, so they cannot drift. The URL prefix follows Eleventy's own `pathPrefix`, so sub-directory deployments (e.g. GitHub Pages under `/repo/`) work without a second knob.
 
 ## Installation
 
@@ -70,12 +70,14 @@ Source directory that contains the client entry points. Used both as esbuild's `
 
 esbuild `outdir` for client entry bundles. Usually matches your Eleventy output directory so bundled `.client.js` files land next to their siblings.
 
-### `urlPrefix`
+### URL prefix (follows Eleventy `pathPrefix`)
 
-- Type: `string`
-- Default: `"/"`
+There is no separate `urlPrefix` option. The plugin reads Eleventy's own [`pathPrefix`](https://www.11ty.dev/docs/config/#deploy-to-a-subdirectory-with-a-path-prefix) at plugin-registration time and uses that as the URL prefix for `<is-land import="...">`.
 
-URL path prefix under which the compiled client module bundles are served.
+- Default deployment (site served at `/`): `pathPrefix: "/"` → `<is-land import="/foo.client.js">`
+- Sub-directory deployment (e.g. GitHub Pages at `https://user.github.io/my-site/`): `pathPrefix: "/my-site/"` → `<is-land import="/my-site/foo.client.js">`
+
+Deployments that serve bundles from a completely different origin or path (e.g. a CDN mounted at `/cdn/` while the site itself is at `/`) fall outside this convention. Use the [`setClientModuleResolver` escape hatch](#escape-hatch-setclientmoduleresolver-for-non-conforming-builds) below.
 
 Combined example:
 
@@ -84,11 +86,10 @@ eleventyConfig.addPlugin(preactIsland, {
   entries: "./content/**/*.client.jsx",
   srcDir: "content",
   outDir: "_site",
-  urlPrefix: "/assets",
 });
 ```
 
-With this config, `content/foo.client.jsx` is bundled to `_site/foo.client.js` and rendered as `<is-land ... import="/assets/foo.client.js">`.
+With this config, `content/foo.client.jsx` is bundled to `_site/foo.client.js`. If Eleventy's `pathPrefix` is `/`, the rendered element is `<is-land ... import="/foo.client.js">`.
 
 ### `preactVersion`
 
@@ -165,9 +166,9 @@ The raw `<is-land>` element remains fully supported — the script injection is 
 The plugin's convention is:
 
 - Client entries live under `<srcDir>/**/*.client.{js,jsx,ts,tsx}`
-- Bundles are served at `<urlPrefix>**/*.client.js`
+- Bundles are served at `<eleventyPathPrefix>**/*.client.js`
 
-If your build doesn't fit this convention — for example, you bundle client code with Vite and it lands at a hashed URL like `/assets/foo-abc123.js`, or you use a different sub-extension like `.island.jsx` — use `<Island>` outside this plugin by installing a custom resolver from the `./island` subpath:
+If your build doesn't fit this convention — for example, you bundle client code with Vite and it lands at a hashed URL like `/assets/foo-abc123.js`, you use a different sub-extension like `.island.jsx`, or your bundles are served from a different origin than the site itself — use `<Island>` outside this plugin by installing a custom resolver from the `./island` subpath:
 
 ```javascript
 // eleventy.config.mjs (no Island plugin needed for the resolver, but you still need it for is-land script injection)
@@ -176,7 +177,7 @@ import { setClientModuleResolver } from "@tuqulore-inc/eleventy-plugin-preact-is
 setClientModuleResolver((moduleUrl) => myBuild.urlFor(moduleUrl));
 ```
 
-- The plugin's `srcDir` / `urlPrefix` options exist so you don't have to write a resolver at all when your build layout is a simple prefix rewrite.
+- The plugin's `srcDir` option (plus Eleventy's `pathPrefix`) exists so you don't have to write a resolver at all when your build layout is a simple prefix rewrite.
 - `setClientModuleResolver` is the low-level extension point that keeps the `<Island>` / `clientComponent` primitives usable across arbitrary conventions.
 
 ## Requirements

--- a/packages/eleventy-plugin-preact-island/README.md
+++ b/packages/eleventy-plugin-preact-island/README.md
@@ -75,7 +75,7 @@ eleventyConfig.addPlugin(preactIsland, { bundle: false });
 
 ### URL prefix (follows Eleventy `pathPrefix`)
 
-There is no `urlPrefix` option. The plugin reads Eleventy's own [`pathPrefix`](https://www.11ty.dev/docs/config/#deploy-to-a-subdirectory-with-a-path-prefix) at plugin-registration time and uses it as the URL prefix for `<is-land import="...">` and for the `is-land` entry in the injected import map.
+There is no `urlPrefix` option. The plugin reads Eleventy's own [`pathPrefix`](https://www.11ty.dev/docs/config/#deploy-to-a-subdirectory-with-a-path-prefix) when it executes and uses it as the URL prefix for `<is-land import="...">` and for the `is-land` entry in the injected import map. Eleventy 3 runs plugins after your config function returns, so a `pathPrefix` declared in the config return object (or via the CLI `--pathprefix`) is already visible to the plugin.
 
 - Default deployment (site served at `/`): `pathPrefix: "/"` → `<is-land import="/foo.client.js">`
 - Sub-directory deployment (e.g. GitHub Pages at `https://user.github.io/my-site/`): `pathPrefix: "/my-site/"` → `<is-land import="/my-site/foo.client.js">`

--- a/packages/eleventy-plugin-preact-island/README.md
+++ b/packages/eleventy-plugin-preact-island/README.md
@@ -4,12 +4,17 @@ Eleventy plugin for Preact partial hydration with is-land.
 
 An Island is the SSR-rendered HTML with client-side JavaScript layered on top; this package handles both sides in one plugin. It:
 
-1. Bundles `*.client.jsx` entry points with esbuild for the browser.
+1. Bundles the client entry points you pass via `entries` with esbuild (opt-in).
 2. Excludes those files from Eleventy template processing.
 3. Injects the browser-side [`@11ty/is-land`](https://github.com/11ty/is-land) + Preact setup into every HTML page.
 4. Provides an `<Island>` wrapper that renders SSR content and emits the matching `<is-land>` element with the correct `import` URL for hydration.
 
-The bundle output layout (`srcDir` / `outDir`) and the hydration import URL are wired from the same options, so they cannot drift. The URL prefix follows Eleventy's own `pathPrefix`, so sub-directory deployments (e.g. GitHub Pages under `/repo/`) work without a second knob.
+Two constants shape the wiring:
+
+- **`srcDir` / `outDir`**: the bundle layout you can customize per project (defaults `"src"` / `"dist"`).
+- **The `.client.{js,jsx,ts,tsx}` sub-extension**: hard-coded in the URL resolver. Files it converts must end with this suffix and are rewritten to `.client.js`. `entries` itself is a free-form glob, but only files matching this suffix will resolve at SSR time.
+
+The URL prefix follows Eleventy's own `pathPrefix`, so sub-directory deployments (e.g. GitHub Pages under `/repo/`) work without a second knob.
 
 ## Installation
 
@@ -32,23 +37,25 @@ export default function (eleventyConfig) {
 
 ## What it does
 
-1. **Bundles `*.client.jsx` files** with esbuild (opt-in via `entries`)
+1. **Bundles client entries** with esbuild — the glob you pass via `entries` (opt-in; if you omit it, no bundling happens and you're expected to produce the `.client.js` bundles yourself, see [Escape hatch](#escape-hatch-setclientmoduleresolver-for-non-conforming-builds))
 2. **Ignores** matching files as Eleventy templates (they're client entries, not pages)
 3. **Copies `is-land.js`** from `@11ty/is-land` to the output directory
 4. **Injects scripts** before `</head>`:
    - Import map for is-land and Preact (from esm.sh CDN)
    - Development-only WebSocket hook for rehydration after hot reload
    - is-land setup script with `Island.addInitType("preact", mount)`
-5. **Wires the URL resolver** so `<Island>` on the SSR side emits the same URL that the bundler produced
+5. **Wires the URL resolver** so `<Island>` on the SSR side emits the same URL that the bundler produced. The resolver requires the `.client.{js,jsx,ts,tsx}` sub-extension.
 
 ## Options
 
 ### `entries`
 
 - Type: `string`
-- Default: `undefined`
+- Default: `undefined` (no bundling)
 
-Glob pattern for client entry points. Files matching this pattern are bundled with esbuild and excluded from Eleventy's template pipeline. When omitted, no bundling happens and no ignore rule is added.
+Glob pattern for client entry points. Files matching this pattern are bundled with esbuild and excluded from Eleventy's template pipeline. When omitted, no bundling happens and no ignore rule is added — this mode is for users who already produce `.client.js` bundles some other way (see [Escape hatch](#escape-hatch-setclientmoduleresolver-for-non-conforming-builds)).
+
+The glob itself is free-form, but the SSR-side URL resolver only accepts source files ending in `.client.{js,jsx,ts,tsx}` (see below). Practically that means you'll want a glob like `./src/**/*.client.jsx`.
 
 ```javascript
 eleventyConfig.addPlugin(preactIsland, {
@@ -62,6 +69,8 @@ eleventyConfig.addPlugin(preactIsland, {
 - Default: `"src"`
 
 Source directory that contains the client entry points. Used both as esbuild's `outbase` (to preserve the source directory structure under `outDir`) and as the marker segment when converting SSR-side client module URLs (e.g. `import.meta.url` inside `foo.client.jsx`) into browser URLs. Should match your Eleventy input directory.
+
+The `.client.{js,jsx,ts,tsx}` sub-extension is not an option — it is hard-coded in the URL resolver, so `<Island component={...}>` will throw at SSR time if the module's file doesn't end in one of those. If you need a different sub-extension (e.g. `.island.jsx`), replace the resolver via [`setClientModuleResolver`](#escape-hatch-setclientmoduleresolver-for-non-conforming-builds).
 
 ### `outDir`
 

--- a/packages/eleventy-plugin-preact-island/README.md
+++ b/packages/eleventy-plugin-preact-island/README.md
@@ -2,10 +2,14 @@
 
 Eleventy plugin for Preact partial hydration with is-land.
 
-This plugin:
+An Island is the SSR-rendered HTML with client-side JavaScript layered on top; this package handles both sides in one plugin. It:
 
-1. Injects the browser-side setup for [`@11ty/is-land`](https://github.com/11ty/is-land) + Preact into every HTML page.
-2. Ships an `<Island>` wrapper component that eliminates the `<is-land>` boilerplate (`type="preact"`, hardcoded `import` URL, `JSON.stringify(props)`, duplicate SSR children).
+1. Bundles `*.client.jsx` entry points with esbuild for the browser.
+2. Excludes those files from Eleventy template processing.
+3. Injects the browser-side [`@11ty/is-land`](https://github.com/11ty/is-land) + Preact setup into every HTML page.
+4. Provides an `<Island>` wrapper that renders SSR content and emits the matching `<is-land>` element with the correct `import` URL for hydration.
+
+All four are wired from a single source of truth (`srcDir` / `outDir` / `urlPrefix`), so the bundle output layout and the hydration import URL cannot drift.
 
 ## Installation
 
@@ -20,20 +24,71 @@ npm install -D @11ty/eleventy preact @tuqulore-inc/eleventy-plugin-preact-island
 import preactIsland from "@tuqulore-inc/eleventy-plugin-preact-island";
 
 export default function (eleventyConfig) {
-  eleventyConfig.addPlugin(preactIsland);
+  eleventyConfig.addPlugin(preactIsland, {
+    entries: "./src/**/*.client.jsx",
+  });
 }
 ```
 
 ## What it does
 
-1. **Copies `is-land.js`** from `@11ty/is-land` to the output directory
-2. **Injects scripts** before `</head>`:
+1. **Bundles `*.client.jsx` files** with esbuild (opt-in via `entries`)
+2. **Ignores** matching files as Eleventy templates (they're client entries, not pages)
+3. **Copies `is-land.js`** from `@11ty/is-land` to the output directory
+4. **Injects scripts** before `</head>`:
    - Import map for is-land and Preact (from esm.sh CDN)
    - Development-only WebSocket hook for rehydration after hot reload
    - is-land setup script with `Island.addInitType("preact", mount)`
-3. **Registers a hydrate module URL resolver** used by the `<Island>` component (see below).
+5. **Wires the URL resolver** so `<Island>` on the SSR side emits the same URL that the bundler produced
 
 ## Options
+
+### `entries`
+
+- Type: `string`
+- Default: `undefined`
+
+Glob pattern for client entry points. Files matching this pattern are bundled with esbuild and excluded from Eleventy's template pipeline. When omitted, no bundling happens and no ignore rule is added.
+
+```javascript
+eleventyConfig.addPlugin(preactIsland, {
+  entries: "./src/**/*.client.jsx",
+});
+```
+
+### `srcDir`
+
+- Type: `string`
+- Default: `"src"`
+
+Source directory that contains the client entry points. Used both as esbuild's `outbase` (to preserve the source directory structure under `outDir`) and as the marker segment when converting SSR-side client module URLs (e.g. `import.meta.url` inside `foo.client.jsx`) into browser URLs. Should match your Eleventy input directory.
+
+### `outDir`
+
+- Type: `string`
+- Default: `"dist"`
+
+esbuild `outdir` for client entry bundles. Usually matches your Eleventy output directory so bundled `.client.js` files land next to their siblings.
+
+### `urlPrefix`
+
+- Type: `string`
+- Default: `"/"`
+
+URL path prefix under which the compiled client module bundles are served.
+
+Combined example:
+
+```javascript
+eleventyConfig.addPlugin(preactIsland, {
+  entries: "./content/**/*.client.jsx",
+  srcDir: "content",
+  outDir: "_site",
+  urlPrefix: "/assets",
+});
+```
+
+With this config, `content/foo.client.jsx` is bundled to `_site/foo.client.js` and rendered as `<is-land ... import="/assets/foo.client.js">`.
 
 ### `preactVersion`
 
@@ -48,43 +103,15 @@ eleventyConfig.addPlugin(preactIsland, {
 });
 ```
 
-### `resolveHydrateUrl`
-
-- Type: `(moduleUrl: string) => string`
-- Default: `createHydrateModuleResolver()` (`srcDir: "src"`, `urlPrefix: "/"`)
-
-Convert an SSR-side hydrate module URL (e.g. `import.meta.url` inside `foo.hydrate.jsx`) into the browser URL where the compiled bundle is served. When using this plugin outside `@tuqulore-inc/eleventy-preset`, pass a resolver that matches your build convention.
-
-```javascript
-import preactIsland from "@tuqulore-inc/eleventy-plugin-preact-island";
-import { createHydrateModuleResolver } from "@tuqulore-inc/eleventy-plugin-preact-island/resolver";
-
-eleventyConfig.addPlugin(preactIsland, {
-  resolveHydrateUrl: createHydrateModuleResolver({
-    srcDir: "content",
-    urlPrefix: "/assets",
-  }),
-});
-```
-
-Or supply an arbitrary function:
-
-```javascript
-eleventyConfig.addPlugin(preactIsland, {
-  resolveHydrateUrl: (moduleUrl) =>
-    moduleUrl.replace(/^.*\/pages\//, "/build/").replace(/\.jsx$/, ".js"),
-});
-```
-
 ## Partial Hydration
 
-### `hydratable(Component, moduleUrl)`
+### `clientComponent(Component, moduleUrl)`
 
-Marks a component as hydratable by attaching its SSR-side module URL. Call once in each `*.hydrate.jsx` file:
+Marks a Preact component as a client component by attaching its SSR-side module URL. Call once in each `*.client.jsx` file:
 
 ```jsx
-// src/counter.hydrate.jsx
-import { hydratable } from "@tuqulore-inc/eleventy-plugin-preact-island/island";
+// src/counter.client.jsx
+import { clientComponent } from "@tuqulore-inc/eleventy-plugin-preact-island/island";
 import { useState } from "preact/hooks";
 
 function Counter() {
@@ -92,16 +119,16 @@ function Counter() {
   return <button onClick={() => setN(n + 1)}>{n}</button>;
 }
 
-export default hydratable(Counter, import.meta.url);
+export default clientComponent(Counter, import.meta.url);
 ```
 
 ### `<Island>`
 
-Wrap a hydratable component in `<is-land>`. Extra props are forwarded to both the SSR render and the client hydration.
+Wrap a client component in `<is-land>`. Extra props are forwarded to both the SSR render and the client hydration.
 
 ```jsx
 import { Island } from "@tuqulore-inc/eleventy-plugin-preact-island/island";
-import Counter from "./counter.hydrate.jsx";
+import Counter from "./counter.client.jsx";
 
 <Island component={Counter} on="interaction" label="click me" />;
 ```
@@ -112,7 +139,7 @@ The example renders (after resolving the import URL):
 <is-land
   land-on:interaction
   type="preact"
-  import="/counter.hydrate.js"
+  import="/counter.client.js"
   props='{"label":"click me"}'
 >
   <button>0</button>
@@ -123,15 +150,34 @@ The example renders (after resolving the import URL):
 
 | Prop        | Type                              | Description                                                                             |
 | ----------- | --------------------------------- | --------------------------------------------------------------------------------------- |
-| `component` | `HydratableComponent`             | Component wrapped with `hydratable()` in its `*.hydrate.jsx` file.                      |
+| `component` | `ClientComponent`                 | Component wrapped with `clientComponent()` in its `*.client.jsx` file.                  |
 | `on`        | `string` (default: `interaction`) | is-land initialization trigger. Rendered as the boolean attribute `land-on:<on>`.       |
 | ...rest     | any                               | Serialized as `props` on `<is-land>` and forwarded to the component's SSR render as-is. |
 
 For parameterized triggers such as `on:media("(min-width: ...)")`, use the raw `<is-land>` element directly; the injected setup script still handles it.
 
-### Backward compatibility
+### Backward compatibility with raw `<is-land>`
 
-The raw `<is-land>` element remains fully supported — this plugin's script injection is unchanged. `<Island>` is a strict addition; existing partial hydration code continues to work.
+The raw `<is-land>` element remains fully supported — the script injection is unchanged. `<Island>` is a strict addition; existing partial hydration code that uses `<is-land>` directly continues to work.
+
+## Escape hatch: `setClientModuleResolver` for non-conforming builds
+
+The plugin's convention is:
+
+- Client entries live under `<srcDir>/**/*.client.{js,jsx,ts,tsx}`
+- Bundles are served at `<urlPrefix>**/*.client.js`
+
+If your build doesn't fit this convention — for example, you bundle client code with Vite and it lands at a hashed URL like `/assets/foo-abc123.js`, or you use a different sub-extension like `.island.jsx` — use `<Island>` outside this plugin by installing a custom resolver from the `./island` subpath:
+
+```javascript
+// eleventy.config.mjs (no Island plugin needed for the resolver, but you still need it for is-land script injection)
+import { setClientModuleResolver } from "@tuqulore-inc/eleventy-plugin-preact-island/island";
+
+setClientModuleResolver((moduleUrl) => myBuild.urlFor(moduleUrl));
+```
+
+- The plugin's `srcDir` / `urlPrefix` options exist so you don't have to write a resolver at all when your build layout is a simple prefix rewrite.
+- `setClientModuleResolver` is the low-level extension point that keeps the `<Island>` / `clientComponent` primitives usable across arbitrary conventions.
 
 ## Requirements
 

--- a/packages/eleventy-plugin-preact-island/README.md
+++ b/packages/eleventy-plugin-preact-island/README.md
@@ -168,17 +168,28 @@ The plugin's convention is:
 - Client entries live under `<srcDir>/**/*.client.{js,jsx,ts,tsx}`
 - Bundles are served at `<eleventyPathPrefix>**/*.client.js`
 
-If your build doesn't fit this convention — for example, you bundle client code with Vite and it lands at a hashed URL like `/assets/foo-abc123.js`, you use a different sub-extension like `.island.jsx`, or your bundles are served from a different origin than the site itself — use `<Island>` outside this plugin by installing a custom resolver from the `./island` subpath:
+If your build doesn't fit this convention — for example, you bundle client code with Vite and it lands at a hashed URL like `/assets/foo-abc123.js`, you use a different sub-extension like `.island.jsx`, or your bundles are served from a different origin than the site itself — you can override just the URL resolver while keeping the plugin's browser-side setup (importmap, is-land script injection, dev rehydration hook).
+
+Do so by registering the plugin normally (without `entries`, so it won't try to bundle for you) and then installing a custom resolver from the `./island` subpath. **Order matters**: the plugin installs its default resolver when it runs, so `setClientModuleResolver` must be called _after_ `addPlugin(preactIsland)` to take effect.
 
 ```javascript
-// eleventy.config.mjs (no Island plugin needed for the resolver, but you still need it for is-land script injection)
+// eleventy.config.mjs
+import preactIsland from "@tuqulore-inc/eleventy-plugin-preact-island";
 import { setClientModuleResolver } from "@tuqulore-inc/eleventy-plugin-preact-island/island";
 
-setClientModuleResolver((moduleUrl) => myBuild.urlFor(moduleUrl));
+export default function (eleventyConfig) {
+  // Registers is-land + Preact browser setup. Skip `entries` because you're
+  // bundling the client code yourself.
+  eleventyConfig.addPlugin(preactIsland);
+
+  // Override the URL resolver installed by the plugin above.
+  setClientModuleResolver((moduleUrl) => myBuild.urlFor(moduleUrl));
+}
 ```
 
 - The plugin's `srcDir` option (plus Eleventy's `pathPrefix`) exists so you don't have to write a resolver at all when your build layout is a simple prefix rewrite.
 - `setClientModuleResolver` is the low-level extension point that keeps the `<Island>` / `clientComponent` primitives usable across arbitrary conventions.
+- Pass `null` to `setClientModuleResolver` to explicitly clear the resolver; anything other than a function or `null` throws `TypeError`.
 
 ## Requirements
 

--- a/packages/eleventy-plugin-preact-island/README.md
+++ b/packages/eleventy-plugin-preact-island/README.md
@@ -2,19 +2,20 @@
 
 Eleventy plugin for Preact partial hydration with is-land.
 
-An Island is the SSR-rendered HTML with client-side JavaScript layered on top; this package handles both sides in one plugin. It:
+An Island is SSR-rendered HTML with client-side JavaScript layered on top; this package handles both sides in one plugin. It is convention-first and zero-config: put your client entries under Eleventy's input directory with the `.client.{js,jsx,ts,tsx}` sub-extension, register the plugin, and it does the rest.
 
-1. Bundles the client entry points you pass via `entries` with esbuild (opt-in).
-2. Excludes those files from Eleventy template processing.
-3. Injects the browser-side [`@11ty/is-land`](https://github.com/11ty/is-land) + Preact setup into every HTML page.
+For any `*.client.{js,jsx,ts,tsx}` file under your Eleventy input directory, it:
+
+1. Bundles it with esbuild (unless you opt out with `bundle: false`).
+2. Excludes it from Eleventy template processing (so client entries are never rendered as pages).
+3. Copies [`@11ty/is-land`](https://github.com/11ty/is-land)'s `is-land.js` to the output directory and injects the browser-side is-land + Preact setup into every HTML page.
 4. Provides an `<Island>` wrapper that renders SSR content and emits the matching `<is-land>` element with the correct `import` URL for hydration.
 
-Two constants shape the wiring:
+## Convention
 
-- **`srcDir` / `outDir`**: the bundle layout you can customize per project (defaults `"src"` / `"dist"`).
-- **The `.client.{js,jsx,ts,tsx}` sub-extension**: hard-coded in the URL resolver. Files it converts must end with this suffix and are rewritten to `.client.js`. `entries` itself is a free-form glob, but only files matching this suffix will resolve at SSR time.
-
-The URL prefix follows Eleventy's own `pathPrefix`, so sub-directory deployments (e.g. GitHub Pages under `/repo/`) work without a second knob.
+- **Input / output directories ride on Eleventy's own configuration.** The plugin reads `eleventyConfig.directories.input` / `.output`, so `setInputDirectory` / `setOutputDirectory` (or the CLI `--input` / `--output`) are the single source of truth. There is no separate `srcDir` / `outDir` knob.
+- **Client entries are discovered by convention:** every `<input>/**/*.client.{js,jsx,ts,tsx}`. A file's sub-extension (`.client.`) is what marks it as a client entry; the compiled bundle is served at `<input-relative path>.client.js`.
+- **The URL prefix follows Eleventy's own [`pathPrefix`](https://www.11ty.dev/docs/config/#deploy-to-a-subdirectory-with-a-path-prefix)**, so sub-directory deployments (e.g. GitHub Pages under `/repo/`) work without a second knob.
 
 ## Installation
 
@@ -29,76 +30,24 @@ npm install -D @11ty/eleventy preact @tuqulore-inc/eleventy-plugin-preact-island
 import preactIsland from "@tuqulore-inc/eleventy-plugin-preact-island";
 
 export default function (eleventyConfig) {
-  eleventyConfig.addPlugin(preactIsland, {
-    entries: "./src/**/*.client.jsx",
-  });
+  eleventyConfig.addPlugin(preactIsland);
 }
 ```
 
+That's it. Author client components as `src/**/*.client.jsx` (or `.tsx` / `.js` / `.ts`) and render them through `<Island>` (see [Partial Hydration](#partial-hydration)).
+
 ## What it does
 
-1. **Bundles client entries** with esbuild — the glob you pass via `entries` (opt-in; if you omit it, no bundling happens and you're expected to produce the `.client.js` bundles yourself, see [Escape hatch](#escape-hatch-setclientmoduleresolver-for-non-conforming-builds))
-2. **Ignores** matching files as Eleventy templates (they're client entries, not pages)
-3. **Copies `is-land.js`** from `@11ty/is-land` to the output directory
+1. **Bundles client entries** with esbuild — every `*.client.{js,jsx,ts,tsx}` under the Eleventy input directory. If none exist, esbuild is skipped, so a site that doesn't use Islands still builds.
+2. **Ignores** those files as Eleventy templates (they're client entries, not pages). This ignore rule is always added, independent of `bundle`.
+3. **Copies `is-land.js`** from `@11ty/is-land` to the output directory.
 4. **Injects scripts** before `</head>`:
    - Import map for is-land and Preact (from esm.sh CDN)
    - Development-only WebSocket hook for rehydration after hot reload
    - is-land setup script with `Island.addInitType("preact", mount)`
-5. **Wires the URL resolver** so `<Island>` on the SSR side emits the same URL that the bundler produced. The resolver requires the `.client.{js,jsx,ts,tsx}` sub-extension.
+5. **Wires the URL resolver** so `<Island>` on the SSR side emits the same URL the bundler produced. Client entries must use the `.client.{js,jsx,ts,tsx}` sub-extension and live under the input directory.
 
 ## Options
-
-### `entries`
-
-- Type: `string`
-- Default: `undefined` (no bundling)
-
-Glob pattern for client entry points. Files matching this pattern are bundled with esbuild and excluded from Eleventy's template pipeline. When omitted, no bundling happens and no ignore rule is added — this mode is for users who already produce `.client.js` bundles some other way (see [Escape hatch](#escape-hatch-setclientmoduleresolver-for-non-conforming-builds)).
-
-The glob itself is free-form, but the SSR-side URL resolver only accepts source files ending in `.client.{js,jsx,ts,tsx}` (see below). Practically that means you'll want a glob like `./src/**/*.client.jsx`.
-
-```javascript
-eleventyConfig.addPlugin(preactIsland, {
-  entries: "./src/**/*.client.jsx",
-});
-```
-
-### `srcDir`
-
-- Type: `string`
-- Default: `"src"`
-
-Source directory that contains the client entry points. Used both as esbuild's `outbase` (to preserve the source directory structure under `outDir`) and as the marker segment when converting SSR-side client module URLs (e.g. `import.meta.url` inside `foo.client.jsx`) into browser URLs. Should match your Eleventy input directory.
-
-The `.client.{js,jsx,ts,tsx}` sub-extension is not an option — it is hard-coded in the URL resolver, so `<Island component={...}>` will throw at SSR time if the module's file doesn't end in one of those. If you need a different sub-extension (e.g. `.island.jsx`), replace the resolver via [`setClientModuleResolver`](#escape-hatch-setclientmoduleresolver-for-non-conforming-builds).
-
-### `outDir`
-
-- Type: `string`
-- Default: `"dist"`
-
-esbuild `outdir` for client entry bundles. Usually matches your Eleventy output directory so bundled `.client.js` files land next to their siblings.
-
-### URL prefix (follows Eleventy `pathPrefix`)
-
-There is no separate `urlPrefix` option. The plugin reads Eleventy's own [`pathPrefix`](https://www.11ty.dev/docs/config/#deploy-to-a-subdirectory-with-a-path-prefix) at plugin-registration time and uses that as the URL prefix for `<is-land import="...">`.
-
-- Default deployment (site served at `/`): `pathPrefix: "/"` → `<is-land import="/foo.client.js">`
-- Sub-directory deployment (e.g. GitHub Pages at `https://user.github.io/my-site/`): `pathPrefix: "/my-site/"` → `<is-land import="/my-site/foo.client.js">`
-
-Deployments that serve bundles from a completely different origin or path (e.g. a CDN mounted at `/cdn/` while the site itself is at `/`) fall outside this convention. Use the [`setClientModuleResolver` escape hatch](#escape-hatch-setclientmoduleresolver-for-non-conforming-builds) below.
-
-Combined example:
-
-```javascript
-eleventyConfig.addPlugin(preactIsland, {
-  entries: "./content/**/*.client.jsx",
-  srcDir: "content",
-  outDir: "_site",
-});
-```
-
-With this config, `content/foo.client.jsx` is bundled to `_site/foo.client.js`. If Eleventy's `pathPrefix` is `/`, the rendered element is `<is-land ... import="/foo.client.js">`.
 
 ### `preactVersion`
 
@@ -112,6 +61,28 @@ eleventyConfig.addPlugin(preactIsland, {
   preactVersion: "10.26.4",
 });
 ```
+
+### `bundle`
+
+- Type: `boolean`
+- Default: `true`
+
+Whether to bundle `*.client.{js,jsx,ts,tsx}` entries with esbuild. Set to `false` to bring your own bundler — everything else stays active: the Eleventy ignore rule, the SSR URL resolver wiring, the `is-land.js` copy, and the browser-side script injection. You are then responsible for producing the `.client.js` bundles at the URLs the resolver expects (`<pathPrefix><input-relative path>.client.js`).
+
+```javascript
+eleventyConfig.addPlugin(preactIsland, { bundle: false });
+```
+
+### URL prefix (follows Eleventy `pathPrefix`)
+
+There is no `urlPrefix` option. The plugin reads Eleventy's own [`pathPrefix`](https://www.11ty.dev/docs/config/#deploy-to-a-subdirectory-with-a-path-prefix) at plugin-registration time and uses it as the URL prefix for `<is-land import="...">` and for the `is-land` entry in the injected import map.
+
+- Default deployment (site served at `/`): `pathPrefix: "/"` → `<is-land import="/foo.client.js">`
+- Sub-directory deployment (e.g. GitHub Pages at `https://user.github.io/my-site/`): `pathPrefix: "/my-site/"` → `<is-land import="/my-site/foo.client.js">`
+
+> [!NOTE]
+>
+> Set the input/output directories with Eleventy's `setInputDirectory` / `setOutputDirectory` in the config function (or the CLI `--input` / `--output`), not from inside another plugin — the Island plugin reads them when it runs, so changing them after it registers is an ordering hazard.
 
 ## Partial Hydration
 
@@ -166,39 +137,11 @@ The example renders (after resolving the import URL):
 
 For parameterized triggers such as `on:media("(min-width: ...)")`, use the raw `<is-land>` element directly; the injected setup script still handles it.
 
-### Backward compatibility with raw `<is-land>`
+## Interoperating with raw `<is-land>`
 
-The raw `<is-land>` element remains fully supported — the script injection is unchanged. `<Island>` is a strict addition; existing partial hydration code that uses `<is-land>` directly continues to work.
+The raw `<is-land>` element remains fully supported — the script injection is unchanged, and existing partial hydration code that writes `<is-land>` by hand keeps working. `<Island>` is a strict addition on top.
 
-## Escape hatch: `setClientModuleResolver` for non-conforming builds
-
-The plugin's convention is:
-
-- Client entries live under `<srcDir>/**/*.client.{js,jsx,ts,tsx}`
-- Bundles are served at `<eleventyPathPrefix>**/*.client.js`
-
-If your build doesn't fit this convention — for example, you bundle client code with Vite and it lands at a hashed URL like `/assets/foo-abc123.js`, you use a different sub-extension like `.island.jsx`, or your bundles are served from a different origin than the site itself — you can override just the URL resolver while keeping the plugin's browser-side setup (importmap, is-land script injection, dev rehydration hook).
-
-Do so by registering the plugin normally (without `entries`, so it won't try to bundle for you) and then installing a custom resolver from the `./island` subpath. **Order matters**: the plugin installs its default resolver when it runs, so `setClientModuleResolver` must be called _after_ `addPlugin(preactIsland)` to take effect.
-
-```javascript
-// eleventy.config.mjs
-import preactIsland from "@tuqulore-inc/eleventy-plugin-preact-island";
-import { setClientModuleResolver } from "@tuqulore-inc/eleventy-plugin-preact-island/island";
-
-export default function (eleventyConfig) {
-  // Registers is-land + Preact browser setup. Skip `entries` because you're
-  // bundling the client code yourself.
-  eleventyConfig.addPlugin(preactIsland);
-
-  // Override the URL resolver installed by the plugin above.
-  setClientModuleResolver((moduleUrl) => myBuild.urlFor(moduleUrl));
-}
-```
-
-- The plugin's `srcDir` option (plus Eleventy's `pathPrefix`) exists so you don't have to write a resolver at all when your build layout is a simple prefix rewrite.
-- `setClientModuleResolver` is the low-level extension point that keeps the `<Island>` / `clientComponent` primitives usable across arbitrary conventions.
-- Pass `null` to `setClientModuleResolver` to explicitly clear the resolver; anything other than a function or `null` throws `TypeError`.
+If you want to control bundling entirely yourself (custom output layout, a different sub-extension, hashed asset URLs, or serving bundles from another origin), you can bypass this plugin's `<Island>` convention and drive [`@11ty/is-land`](https://github.com/11ty/is-land) directly — write the `<is-land>` elements and their `import` URLs yourself. The plugin's browser-side setup (import map, is-land script, dev rehydration hook) still applies to those elements.
 
 ## Requirements
 

--- a/packages/eleventy-plugin-preact-island/index.d.ts
+++ b/packages/eleventy-plugin-preact-island/index.d.ts
@@ -28,11 +28,6 @@ export interface PluginOptions {
    * @default "dist"
    */
   outDir?: string;
-  /**
-   * URL path prefix where the compiled client module bundles are served.
-   * @default "/"
-   */
-  urlPrefix?: string;
 }
 
 /**

--- a/packages/eleventy-plugin-preact-island/index.d.ts
+++ b/packages/eleventy-plugin-preact-island/index.d.ts
@@ -1,5 +1,4 @@
 import type { UserConfig } from "@11ty/eleventy";
-import type { HydrateModuleResolver } from "./resolver.js";
 
 export interface PluginOptions {
   /**
@@ -8,12 +7,32 @@ export interface PluginOptions {
    */
   preactVersion?: string;
   /**
-   * Convert an SSR-side hydrate module URL (e.g. `import.meta.url` inside a
-   * `*.hydrate.jsx` file) into the browser URL where the compiled bundle is
-   * served. Defaults to `createHydrateModuleResolver()` which assumes `src/**`
-   * sources served under `/`.
+   * Glob pattern for client entry points (e.g., `"./src/**\/*.client.jsx"`).
+   * When provided, matching files are:
+   * - Bundled with esbuild
+   * - Ignored by Eleventy (not processed as templates)
+   * When omitted, no bundling happens and no ignore rule is added.
    */
-  resolveHydrateUrl?: HydrateModuleResolver;
+  entries?: string;
+  /**
+   * Source directory that contains client entry points. Used as esbuild
+   * `outbase` and as the marker segment when converting SSR-side client module
+   * URLs (e.g. `import.meta.url` inside a `*.client.jsx` file) to browser URLs.
+   * Should match your Eleventy input directory.
+   * @default "src"
+   */
+  srcDir?: string;
+  /**
+   * esbuild `outdir` for client entry bundles. Usually matches the Eleventy
+   * output directory so bundled `.client.js` files land next to their siblings.
+   * @default "dist"
+   */
+  outDir?: string;
+  /**
+   * URL path prefix where the compiled client module bundles are served.
+   * @default "/"
+   */
+  urlPrefix?: string;
 }
 
 /**

--- a/packages/eleventy-plugin-preact-island/index.d.ts
+++ b/packages/eleventy-plugin-preact-island/index.d.ts
@@ -7,27 +7,13 @@ export interface PluginOptions {
    */
   preactVersion?: string;
   /**
-   * Glob pattern for client entry points (e.g., `"./src/**\/*.client.jsx"`).
-   * When provided, matching files are:
-   * - Bundled with esbuild
-   * - Ignored by Eleventy (not processed as templates)
-   * When omitted, no bundling happens and no ignore rule is added.
+   * Bundle `*.client.{js,jsx,ts,tsx}` entries with esbuild. Set to `false` to
+   * bring your own bundler; the plugin still adds the Eleventy ignore rule,
+   * wires the SSR URL resolver, copies `is-land.js`, and injects the browser
+   * setup.
+   * @default true
    */
-  entries?: string;
-  /**
-   * Source directory that contains client entry points. Used as esbuild
-   * `outbase` and as the marker segment when converting SSR-side client module
-   * URLs (e.g. `import.meta.url` inside a `*.client.jsx` file) to browser URLs.
-   * Should match your Eleventy input directory.
-   * @default "src"
-   */
-  srcDir?: string;
-  /**
-   * esbuild `outdir` for client entry bundles. Usually matches the Eleventy
-   * output directory so bundled `.client.js` files land next to their siblings.
-   * @default "dist"
-   */
-  outDir?: string;
+  bundle?: boolean;
 }
 
 /**

--- a/packages/eleventy-plugin-preact-island/index.mjs
+++ b/packages/eleventy-plugin-preact-island/index.mjs
@@ -1,31 +1,31 @@
 import url from "node:url";
 import * as esbuild from "esbuild";
-import { setClientModuleResolver } from "./island.mjs";
-import { createClientModuleResolver } from "./resolver.mjs";
+import fg from "fast-glob";
+import { _setClientModuleResolver } from "./island.mjs";
+import { createClientModuleResolver, normalizeUrlPrefix } from "./resolver.mjs";
 
 /**
  * Eleventy plugin for Preact partial hydration with is-land.
  *
- * Owns the entire client boundary:
- * - Bundles `*.client.jsx` entries with esbuild
- * - Excludes them from Eleventy template processing (`ignores.add`)
+ * Zero-config and convention-first: it owns the entire client boundary for
+ * `*.client.{js,jsx,ts,tsx}` files under Eleventy's input directory:
+ * - Bundles them with esbuild (unless `bundle: false`)
+ * - Excludes them from Eleventy template processing (`ignores.add`, always)
  * - Wires the SSR-side `<Island>` component's URL resolver to match the bundle
- *   output layout (`srcDir` / `outDir`), automatically following Eleventy's
- *   own `pathPrefix` for the URL side
+ *   output layout, following Eleventy's own input directory and `pathPrefix`
  * - Injects the browser-side is-land + Preact setup into every HTML page
+ *
+ * Input/output directories ride on Eleventy's own configuration via
+ * `eleventyConfig.directories` (the userspace live getter that reflects
+ * `setInputDirectory`/`setOutputDirectory`). NOTE: `eleventyConfig.dir` is not
+ * used because it does not reflect those setters during plugin execution.
  *
  * @param {import("@11ty/eleventy").UserConfig} eleventyConfig
  * @param {Object} [pluginOptions]
  * @param {string} [pluginOptions.preactVersion] - Preact version for esm.sh CDN
- * @param {string} [pluginOptions.entries] - Glob pattern for client entry
- *   points (e.g. `"./src/**\/*.client.jsx"`). When provided, matching files are
- *   bundled by esbuild and ignored by Eleventy as templates. When omitted, no
- *   bundling happens and no ignore rule is added.
- * @param {string} [pluginOptions.srcDir="src"] - Source directory that contains
- *   client entry points. Used as esbuild `outbase` and as the marker segment
- *   in the SSR module URL → browser URL conversion.
- * @param {string} [pluginOptions.outDir="dist"] - esbuild `outdir` for client
- *   entry bundles. Usually matches the Eleventy output directory.
+ * @param {boolean} [pluginOptions.bundle=true] - Bundle client entries with
+ *   esbuild. Set to `false` to bring your own bundler; the ignore rule,
+ *   resolver wiring, is-land.js copy, and script injection stay active.
  */
 export default function (eleventyConfig, pluginOptions = {}) {
   try {
@@ -34,53 +34,68 @@ export default function (eleventyConfig, pluginOptions = {}) {
     console.log(`[eleventy-plugin-preact-island] WARN: ${e.message}`);
   }
 
-  const {
-    preactVersion = "",
-    entries,
-    srcDir = "src",
-    outDir = "dist",
-  } = pluginOptions;
+  const { preactVersion = "", bundle = true } = pluginOptions;
 
-  // SSR-side URL resolver: srcDir is our own convention; the URL prefix
-  // follows Eleventy's own pathPrefix so that sub-directory deployments
+  // Ride on Eleventy's own input/output directories (normalized, e.g. "./src/").
+  const inputDir = eleventyConfig.directories.input;
+  const outputDir = eleventyConfig.directories.output;
+  const clientGlob = `${inputDir}**/*.client.{js,jsx,ts,tsx}`;
+  const urlPrefix = normalizeUrlPrefix(eleventyConfig.pathPrefix ?? "/");
+
+  // SSR-side URL resolver: the input directory is our own convention; the URL
+  // prefix follows Eleventy's own pathPrefix so that sub-directory deployments
   // (e.g. GitHub Pages under `/repo/`) work without a second knob.
-  // Non-conforming builds can call `setClientModuleResolver` from the
-  // `./island` subpath instead of going through this plugin.
-  setClientModuleResolver(
+  _setClientModuleResolver(
     createClientModuleResolver({
-      srcDir,
-      urlPrefix: eleventyConfig.pathPrefix ?? "/",
+      inputDir,
+      urlPrefix,
     }),
   );
 
-  // Client entry bundling (opt-in via `entries`).
-  if (entries) {
-    // Convert glob to ignore pattern (remove leading ./)
-    const ignorePattern = entries.replace(/^\.\//, "");
-    eleventyConfig.ignores.add(ignorePattern);
+  // Always exclude client entries from the Eleventy template pipeline — this is
+  // part of the convention and independent of who bundles them.
+  eleventyConfig.ignores.add(clientGlob);
 
+  // Client entry bundling (default; disable with `bundle: false`).
+  if (bundle) {
     // watch/serve モードでは Eleventy の再ビルド毎に `eleventy.before` が発火する。
     // esbuild.context()+ctx.watch() を毎回作ると watcher/ファイルハンドルが
     // 増殖してリークするため、context は初回のみ作って再利用する。
     // build モードは 1 回きりなのでその都度 esbuild.build() で完結する。
     let watchCtx = null;
     eleventyConfig.on("eleventy.before", async ({ runMode }) => {
+      // watch context 生成後は entries を固定 (esbuild 側の watcher が再ビルドを担う)。
+      // NOTE: そのため watch 開始後に追加された .client ファイルは Eleventy 再起動まで
+      // 拾われない。旧来の glob 文字列方式でも esbuild は context 生成時に一度だけ glob を
+      // 解決するためパリティであり許容。
+      if (watchCtx) return;
+
+      // NOTE: エントリは明示ファイルリストで渡す (esbuild のワイルドカードはブレース展開
+      // {jsx,tsx} 未対応)。0 件時は esbuild を呼ばずスキップし、Island を使わないサイトでも
+      // ビルドが通るようにする。
+      // NOTE: fast-glob は node_modules をデフォルト除外しないため明示する。
+      // input が "." (プロジェクトルート) の構成で依存パッケージ内の *.client.* を
+      // 誤ってバンドルしない・毎ビルド node_modules を走査しないための guard。
+      const entryPoints = await fg(clientGlob, {
+        ignore: ["**/node_modules/**"],
+      });
+      if (entryPoints.length === 0) return;
+
       /** @type {import("esbuild").BuildOptions} */
       const options = {
         bundle: true,
-        entryPoints: [entries],
+        entryPoints,
         external: ["preact"],
         format: "esm",
         jsx: "automatic",
         jsxImportSource: "preact",
-        outbase: srcDir,
-        outdir: outDir,
+        outbase: inputDir,
+        outdir: outputDir,
       };
       if (runMode === "build") {
         await esbuild.build(options);
         return;
       }
-      if (watchCtx) return;
       watchCtx = await esbuild.context(options);
       await watchCtx.watch();
     });
@@ -95,7 +110,7 @@ export default function (eleventyConfig, pluginOptions = {}) {
   const generateImportMap = () => `<script type="importmap">
 {
   "imports": {
-    "is-land": "/is-land.js",
+    "is-land": "${urlPrefix}is-land.js",
     "preact": "https://esm.sh/preact${preactSuffix}",
     "preact/hooks": "https://esm.sh/preact${preactSuffix}/hooks?external=preact",
     "preact/jsx-runtime": "https://esm.sh/preact${preactSuffix}/jsx-runtime?external=preact"

--- a/packages/eleventy-plugin-preact-island/index.mjs
+++ b/packages/eleventy-plugin-preact-island/index.mjs
@@ -1,17 +1,32 @@
 import url from "node:url";
-import { _setHydrateModuleResolver } from "./island.mjs";
-import { createHydrateModuleResolver } from "./resolver.mjs";
+import * as esbuild from "esbuild";
+import { setClientModuleResolver } from "./island.mjs";
+import { createClientModuleResolver } from "./resolver.mjs";
 
 /**
- * Eleventy plugin for Preact partial hydration with is-land
+ * Eleventy plugin for Preact partial hydration with is-land.
+ *
+ * Owns the entire client boundary:
+ * - Bundles `*.client.jsx` entries with esbuild
+ * - Excludes them from Eleventy template processing (`ignores.add`)
+ * - Wires the SSR-side `<Island>` component's URL resolver to match the bundle
+ *   output layout, from a single source of truth (`srcDir` / `outDir` / `urlPrefix`)
+ * - Injects the browser-side is-land + Preact setup into every HTML page
+ *
  * @param {import("@11ty/eleventy").UserConfig} eleventyConfig
- * @param {Object} pluginOptions
+ * @param {Object} [pluginOptions]
  * @param {string} [pluginOptions.preactVersion] - Preact version for esm.sh CDN
- * @param {(moduleUrl: string) => string} [pluginOptions.resolveHydrateUrl] -
- *   Convert an SSR-side hydrate module URL (e.g. `import.meta.url` inside a
- *   `*.hydrate.jsx` file) into the browser URL of the compiled bundle. Defaults
- *   to `createHydrateModuleResolver()` which assumes `src/**` sources served
- *   under `/`.
+ * @param {string} [pluginOptions.entries] - Glob pattern for client entry
+ *   points (e.g. `"./src/**\/*.client.jsx"`). When provided, matching files are
+ *   bundled by esbuild and ignored by Eleventy as templates. When omitted, no
+ *   bundling happens and no ignore rule is added.
+ * @param {string} [pluginOptions.srcDir="src"] - Source directory that contains
+ *   client entry points. Used as esbuild `outbase` and as the marker segment
+ *   in the SSR module URL → browser URL conversion.
+ * @param {string} [pluginOptions.outDir="dist"] - esbuild `outdir` for client
+ *   entry bundles. Usually matches the Eleventy output directory.
+ * @param {string} [pluginOptions.urlPrefix="/"] - URL path prefix where the
+ *   compiled client module bundles are served.
  */
 export default function (eleventyConfig, pluginOptions = {}) {
   try {
@@ -22,10 +37,43 @@ export default function (eleventyConfig, pluginOptions = {}) {
 
   const {
     preactVersion = "",
-    resolveHydrateUrl = createHydrateModuleResolver(),
+    entries,
+    srcDir = "src",
+    outDir = "dist",
+    urlPrefix = "/",
   } = pluginOptions;
 
-  _setHydrateModuleResolver(resolveHydrateUrl);
+  // SSR-side URL resolver: single source of truth is (srcDir, urlPrefix).
+  // Non-conforming builds can call `setClientModuleResolver` from the
+  // `./island` subpath instead of going through this plugin.
+  setClientModuleResolver(createClientModuleResolver({ srcDir, urlPrefix }));
+
+  // Client entry bundling (opt-in via `entries`).
+  if (entries) {
+    // Convert glob to ignore pattern (remove leading ./)
+    const ignorePattern = entries.replace(/^\.\//, "");
+    eleventyConfig.ignores.add(ignorePattern);
+
+    eleventyConfig.on("eleventy.before", async ({ runMode }) => {
+      /** @type {import("esbuild").BuildOptions} */
+      const options = {
+        bundle: true,
+        entryPoints: [entries],
+        external: ["preact"],
+        format: "esm",
+        jsx: "automatic",
+        jsxImportSource: "preact",
+        outbase: srcDir,
+        outdir: outDir,
+      };
+      if (runMode === "build") {
+        await esbuild.build(options);
+      } else {
+        const ctx = await esbuild.context(options);
+        await ctx.watch();
+      }
+    });
+  }
 
   // Copy is-land.js to output directory
   eleventyConfig.addPassthroughCopy({

--- a/packages/eleventy-plugin-preact-island/index.mjs
+++ b/packages/eleventy-plugin-preact-island/index.mjs
@@ -10,7 +10,8 @@ import { createClientModuleResolver } from "./resolver.mjs";
  * - Bundles `*.client.jsx` entries with esbuild
  * - Excludes them from Eleventy template processing (`ignores.add`)
  * - Wires the SSR-side `<Island>` component's URL resolver to match the bundle
- *   output layout, from a single source of truth (`srcDir` / `outDir` / `urlPrefix`)
+ *   output layout (`srcDir` / `outDir`), automatically following Eleventy's
+ *   own `pathPrefix` for the URL side
  * - Injects the browser-side is-land + Preact setup into every HTML page
  *
  * @param {import("@11ty/eleventy").UserConfig} eleventyConfig
@@ -25,8 +26,6 @@ import { createClientModuleResolver } from "./resolver.mjs";
  *   in the SSR module URL → browser URL conversion.
  * @param {string} [pluginOptions.outDir="dist"] - esbuild `outdir` for client
  *   entry bundles. Usually matches the Eleventy output directory.
- * @param {string} [pluginOptions.urlPrefix="/"] - URL path prefix where the
- *   compiled client module bundles are served.
  */
 export default function (eleventyConfig, pluginOptions = {}) {
   try {
@@ -40,13 +39,19 @@ export default function (eleventyConfig, pluginOptions = {}) {
     entries,
     srcDir = "src",
     outDir = "dist",
-    urlPrefix = "/",
   } = pluginOptions;
 
-  // SSR-side URL resolver: single source of truth is (srcDir, urlPrefix).
+  // SSR-side URL resolver: srcDir is our own convention; the URL prefix
+  // follows Eleventy's own pathPrefix so that sub-directory deployments
+  // (e.g. GitHub Pages under `/repo/`) work without a second knob.
   // Non-conforming builds can call `setClientModuleResolver` from the
   // `./island` subpath instead of going through this plugin.
-  setClientModuleResolver(createClientModuleResolver({ srcDir, urlPrefix }));
+  setClientModuleResolver(
+    createClientModuleResolver({
+      srcDir,
+      urlPrefix: eleventyConfig.pathPrefix ?? "/",
+    }),
+  );
 
   // Client entry bundling (opt-in via `entries`).
   if (entries) {

--- a/packages/eleventy-plugin-preact-island/index.mjs
+++ b/packages/eleventy-plugin-preact-island/index.mjs
@@ -59,6 +59,11 @@ export default function (eleventyConfig, pluginOptions = {}) {
     const ignorePattern = entries.replace(/^\.\//, "");
     eleventyConfig.ignores.add(ignorePattern);
 
+    // watch/serve モードでは Eleventy の再ビルド毎に `eleventy.before` が発火する。
+    // esbuild.context()+ctx.watch() を毎回作ると watcher/ファイルハンドルが
+    // 増殖してリークするため、context は初回のみ作って再利用する。
+    // build モードは 1 回きりなのでその都度 esbuild.build() で完結する。
+    let watchCtx = null;
     eleventyConfig.on("eleventy.before", async ({ runMode }) => {
       /** @type {import("esbuild").BuildOptions} */
       const options = {
@@ -73,10 +78,11 @@ export default function (eleventyConfig, pluginOptions = {}) {
       };
       if (runMode === "build") {
         await esbuild.build(options);
-      } else {
-        const ctx = await esbuild.context(options);
-        await ctx.watch();
+        return;
       }
+      if (watchCtx) return;
+      watchCtx = await esbuild.context(options);
+      await watchCtx.watch();
     });
   }
 

--- a/packages/eleventy-plugin-preact-island/index.test.mjs
+++ b/packages/eleventy-plugin-preact-island/index.test.mjs
@@ -9,16 +9,26 @@ import { Island, clientComponent } from "./island.mjs";
  * Minimal UserConfig stub carrying only what the plugin actually reads.
  * `versionCheck` is called defensively; `addPassthroughCopy` / `addTransform`
  * are called unconditionally in the plugin body. `pathPrefix` is the input
- * under test.
+ * under test. `on` records event handlers so tests can invoke `eleventy.before`
+ * directly to exercise watch/build branches without spinning up Eleventy.
  */
 function makeEleventyConfigStub({ pathPrefix } = {}) {
+  const eventHandlers = new Map();
   return {
     pathPrefix,
     versionCheck() {},
     addPassthroughCopy() {},
     addTransform() {},
     ignores: { add() {} },
-    on() {},
+    on(event, handler) {
+      if (!eventHandlers.has(event)) eventHandlers.set(event, []);
+      eventHandlers.get(event).push(handler);
+    },
+    async _emit(event, arg) {
+      for (const handler of eventHandlers.get(event) ?? []) {
+        await handler(arg);
+      }
+    },
   };
 }
 

--- a/packages/eleventy-plugin-preact-island/index.test.mjs
+++ b/packages/eleventy-plugin-preact-island/index.test.mjs
@@ -166,4 +166,15 @@ describe("Island plugin ignore ルール (常時追加)", () => {
       "./src/**/*.client.{js,jsx,ts,tsx}",
     ]);
   });
+
+  // NOTE: Eleventy の directories.input は常に「./ 前置 + 末尾スラッシュ」に正規化
+  // される (ProjectDirectories.normalizeDirectory)。input 未設定 (プロジェクト
+  // ルート) の正規化形 "./" でも有効な glob になることをここで固定する。
+  it("input がプロジェクトルート (正規化形 './') でも有効な glob を追加する", () => {
+    const config = makeEleventyConfigStub({ input: "./" });
+    preactIsland(config);
+    assert.deepStrictEqual(config._ignoreAdds, [
+      "./**/*.client.{js,jsx,ts,tsx}",
+    ]);
+  });
 });

--- a/packages/eleventy-plugin-preact-island/index.test.mjs
+++ b/packages/eleventy-plugin-preact-island/index.test.mjs
@@ -8,21 +8,43 @@ import { Island, clientComponent } from "./island.mjs";
 /**
  * Minimal UserConfig stub carrying only what the plugin actually reads.
  * `versionCheck` is called defensively; `addPassthroughCopy` / `addTransform`
- * are called unconditionally in the plugin body. `pathPrefix` is the input
- * under test. `on` records event handlers so tests can invoke `eleventy.before`
- * directly to exercise watch/build branches without spinning up Eleventy.
+ * are called unconditionally in the plugin body. `directories` mirrors
+ * Eleventy's userspace live getter (input/output). `pathPrefix` and `input`
+ * are the inputs under test. `on` records event handlers so tests can inspect
+ * registration and invoke `eleventy.before` without spinning up Eleventy.
+ * `ignores.add` records patterns so tests can assert the always-on ignore rule.
  */
-function makeEleventyConfigStub({ pathPrefix } = {}) {
+function makeEleventyConfigStub({
+  pathPrefix,
+  input = "/proj/src/",
+  output = "/proj/dist/",
+} = {}) {
   const eventHandlers = new Map();
+  const ignoreAdds = [];
+  const transforms = new Map();
   return {
     pathPrefix,
+    directories: { input, output },
     versionCheck() {},
     addPassthroughCopy() {},
-    addTransform() {},
-    ignores: { add() {} },
+    addTransform(name, fn) {
+      transforms.set(name, fn);
+    },
+    _transform(name, content, outputPath) {
+      return transforms.get(name)(content, outputPath);
+    },
+    ignores: {
+      add(pattern) {
+        ignoreAdds.push(pattern);
+      },
+    },
+    _ignoreAdds: ignoreAdds,
     on(event, handler) {
       if (!eventHandlers.has(event)) eventHandlers.set(event, []);
       eventHandlers.get(event).push(handler);
+    },
+    _hasHandler(event) {
+      return (eventHandlers.get(event) ?? []).length > 0;
     },
     async _emit(event, arg) {
       for (const handler of eventHandlers.get(event) ?? []) {
@@ -32,10 +54,10 @@ function makeEleventyConfigStub({ pathPrefix } = {}) {
   };
 }
 
-describe("Island plugin URL prefix ↔ Eleventy pathPrefix", () => {
+describe("Island plugin URL prefix ↔ Eleventy pathPrefix / directories", () => {
   it("pathPrefix 未設定 (デフォルト /) では import が / から始まる", () => {
     const config = makeEleventyConfigStub({ pathPrefix: "/" });
-    preactIsland(config, { srcDir: "src" });
+    preactIsland(config);
 
     const Foo = clientComponent(
       () => h("span", null, "x"),
@@ -47,7 +69,7 @@ describe("Island plugin URL prefix ↔ Eleventy pathPrefix", () => {
 
   it("pathPrefix が undefined (Eleventy 起動前) でもフォールバックで / を使う", () => {
     const config = makeEleventyConfigStub({ pathPrefix: undefined });
-    preactIsland(config, { srcDir: "src" });
+    preactIsland(config);
 
     const Foo = clientComponent(() => null, "file:///proj/src/foo.client.jsx");
     const html = render(h(Island, { component: Foo }));
@@ -56,7 +78,7 @@ describe("Island plugin URL prefix ↔ Eleventy pathPrefix", () => {
 
   it("pathPrefix=/blog/ ではサブディレクトリデプロイの URL を反映する", () => {
     const config = makeEleventyConfigStub({ pathPrefix: "/blog/" });
-    preactIsland(config, { srcDir: "src" });
+    preactIsland(config);
 
     const Foo = clientComponent(() => null, "file:///proj/src/foo.client.jsx");
     const html = render(h(Island, { component: Foo }));
@@ -65,16 +87,19 @@ describe("Island plugin URL prefix ↔ Eleventy pathPrefix", () => {
 
   it("pathPrefix=/blog (末尾スラッシュ無し) も正規化されて /blog/foo.client.js になる", () => {
     const config = makeEleventyConfigStub({ pathPrefix: "/blog" });
-    preactIsland(config, { srcDir: "src" });
+    preactIsland(config);
 
     const Foo = clientComponent(() => null, "file:///proj/src/foo.client.jsx");
     const html = render(h(Island, { component: Foo }));
     assert.match(html, /import="\/blog\/foo\.client\.js"/);
   });
 
-  it("カスタム srcDir と pathPrefix を併用できる", () => {
-    const config = makeEleventyConfigStub({ pathPrefix: "/assets/" });
-    preactIsland(config, { srcDir: "content" });
+  it("directories.input に追随する (カスタム input と pathPrefix を併用)", () => {
+    const config = makeEleventyConfigStub({
+      pathPrefix: "/assets/",
+      input: "/proj/content/",
+    });
+    preactIsland(config);
 
     const Foo = clientComponent(
       () => null,
@@ -82,5 +107,63 @@ describe("Island plugin URL prefix ↔ Eleventy pathPrefix", () => {
     );
     const html = render(h(Island, { component: Foo }));
     assert.match(html, /import="\/assets\/foo\.client\.js"/);
+  });
+});
+
+describe("Island plugin importmap ↔ Eleventy pathPrefix", () => {
+  it("pathPrefix=/blog/ では importmap の is-land も /blog/is-land.js を指す", () => {
+    const config = makeEleventyConfigStub({ pathPrefix: "/blog/" });
+    preactIsland(config);
+
+    const html = config._transform(
+      "preact-island-inject",
+      "<html><head></head><body></body></html>",
+      "dist/index.html",
+    );
+    assert.match(html, /"is-land": "\/blog\/is-land\.js"/);
+  });
+
+  it("pathPrefix 未設定では importmap の is-land は /is-land.js を指す", () => {
+    const config = makeEleventyConfigStub({ pathPrefix: undefined });
+    preactIsland(config);
+
+    const html = config._transform(
+      "preact-island-inject",
+      "<html><head></head><body></body></html>",
+      "dist/index.html",
+    );
+    assert.match(html, /"is-land": "\/is-land\.js"/);
+  });
+});
+
+describe("Island plugin bundle オプション", () => {
+  it("デフォルト (bundle 省略) は esbuild 用の eleventy.before ハンドラを登録する", () => {
+    const config = makeEleventyConfigStub();
+    preactIsland(config);
+    assert.ok(config._hasHandler("eleventy.before"));
+  });
+
+  it("bundle: false では eleventy.before ハンドラを登録しない (esbuild を止める)", () => {
+    const config = makeEleventyConfigStub();
+    preactIsland(config, { bundle: false });
+    assert.ok(!config._hasHandler("eleventy.before"));
+  });
+});
+
+describe("Island plugin ignore ルール (常時追加)", () => {
+  it("bundle デフォルトでも .client.* を input 配下で ignore に追加する", () => {
+    const config = makeEleventyConfigStub({ input: "./src/" });
+    preactIsland(config);
+    assert.deepStrictEqual(config._ignoreAdds, [
+      "./src/**/*.client.{js,jsx,ts,tsx}",
+    ]);
+  });
+
+  it("bundle: false でも .client.* を ignore に追加する (バンドラー選択と独立)", () => {
+    const config = makeEleventyConfigStub({ input: "./src/" });
+    preactIsland(config, { bundle: false });
+    assert.deepStrictEqual(config._ignoreAdds, [
+      "./src/**/*.client.{js,jsx,ts,tsx}",
+    ]);
   });
 });

--- a/packages/eleventy-plugin-preact-island/index.test.mjs
+++ b/packages/eleventy-plugin-preact-island/index.test.mjs
@@ -1,0 +1,76 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { h } from "preact";
+import { render } from "preact-render-to-string";
+import preactIsland from "./index.mjs";
+import { Island, clientComponent } from "./island.mjs";
+
+/**
+ * Minimal UserConfig stub carrying only what the plugin actually reads.
+ * `versionCheck` is called defensively; `addPassthroughCopy` / `addTransform`
+ * are called unconditionally in the plugin body. `pathPrefix` is the input
+ * under test.
+ */
+function makeEleventyConfigStub({ pathPrefix } = {}) {
+  return {
+    pathPrefix,
+    versionCheck() {},
+    addPassthroughCopy() {},
+    addTransform() {},
+    ignores: { add() {} },
+    on() {},
+  };
+}
+
+describe("Island plugin URL prefix ↔ Eleventy pathPrefix", () => {
+  it("pathPrefix 未設定 (デフォルト /) では import が / から始まる", () => {
+    const config = makeEleventyConfigStub({ pathPrefix: "/" });
+    preactIsland(config, { srcDir: "src" });
+
+    const Foo = clientComponent(
+      () => h("span", null, "x"),
+      "file:///proj/src/foo.client.jsx",
+    );
+    const html = render(h(Island, { component: Foo }));
+    assert.match(html, /import="\/foo\.client\.js"/);
+  });
+
+  it("pathPrefix が undefined (Eleventy 起動前) でもフォールバックで / を使う", () => {
+    const config = makeEleventyConfigStub({ pathPrefix: undefined });
+    preactIsland(config, { srcDir: "src" });
+
+    const Foo = clientComponent(() => null, "file:///proj/src/foo.client.jsx");
+    const html = render(h(Island, { component: Foo }));
+    assert.match(html, /import="\/foo\.client\.js"/);
+  });
+
+  it("pathPrefix=/blog/ ではサブディレクトリデプロイの URL を反映する", () => {
+    const config = makeEleventyConfigStub({ pathPrefix: "/blog/" });
+    preactIsland(config, { srcDir: "src" });
+
+    const Foo = clientComponent(() => null, "file:///proj/src/foo.client.jsx");
+    const html = render(h(Island, { component: Foo }));
+    assert.match(html, /import="\/blog\/foo\.client\.js"/);
+  });
+
+  it("pathPrefix=/blog (末尾スラッシュ無し) も正規化されて /blog/foo.client.js になる", () => {
+    const config = makeEleventyConfigStub({ pathPrefix: "/blog" });
+    preactIsland(config, { srcDir: "src" });
+
+    const Foo = clientComponent(() => null, "file:///proj/src/foo.client.jsx");
+    const html = render(h(Island, { component: Foo }));
+    assert.match(html, /import="\/blog\/foo\.client\.js"/);
+  });
+
+  it("カスタム srcDir と pathPrefix を併用できる", () => {
+    const config = makeEleventyConfigStub({ pathPrefix: "/assets/" });
+    preactIsland(config, { srcDir: "content" });
+
+    const Foo = clientComponent(
+      () => null,
+      "file:///proj/content/foo.client.jsx",
+    );
+    const html = render(h(Island, { component: Foo }));
+    assert.match(html, /import="\/assets\/foo\.client\.js"/);
+  });
+});

--- a/packages/eleventy-plugin-preact-island/island.d.ts
+++ b/packages/eleventy-plugin-preact-island/island.d.ts
@@ -32,15 +32,3 @@ export interface IslandProps<P = Record<string, unknown>> {
 export function Island<P = Record<string, unknown>>(
   props: IslandProps<P>,
 ): VNode;
-
-/**
- * Install the client module URL resolver. Called by the Eleventy plugin during
- * config setup. Also part of the public API for users who want to use `<Island>`
- * without adopting this package's file naming / URL convention.
- *
- * Pass `null` to explicitly clear the currently installed resolver.
- * Anything else throws `TypeError`.
- */
-export function setClientModuleResolver(
-  resolver: ((moduleUrl: string) => string) | null,
-): void;

--- a/packages/eleventy-plugin-preact-island/island.d.ts
+++ b/packages/eleventy-plugin-preact-island/island.d.ts
@@ -37,7 +37,10 @@ export function Island<P = Record<string, unknown>>(
  * Install the client module URL resolver. Called by the Eleventy plugin during
  * config setup. Also part of the public API for users who want to use `<Island>`
  * without adopting this package's file naming / URL convention.
+ *
+ * Pass `null` to explicitly clear the currently installed resolver.
+ * Anything else throws `TypeError`.
  */
 export function setClientModuleResolver(
-  resolver: (moduleUrl: string) => string,
+  resolver: ((moduleUrl: string) => string) | null,
 ): void;

--- a/packages/eleventy-plugin-preact-island/island.d.ts
+++ b/packages/eleventy-plugin-preact-island/island.d.ts
@@ -1,21 +1,20 @@
 import type { ComponentType, VNode } from "preact";
 
-export type HydratableComponent<P = Record<string, unknown>> =
-  ComponentType<P> & {
-    __hydrateModuleUrl: string;
-  };
+export type ClientComponent<P = Record<string, unknown>> = ComponentType<P> & {
+  __clientModuleUrl: string;
+};
 
 /**
- * Attach the SSR-side module URL as metadata to a hydration component.
- * Call in each `*.hydrate.jsx` file: `export default hydratable(Component, import.meta.url);`
+ * Attach the SSR-side module URL as metadata to a client component.
+ * Call in each `*.client.jsx` file: `export default clientComponent(Component, import.meta.url);`
  */
-export function hydratable<P = Record<string, unknown>>(
+export function clientComponent<P = Record<string, unknown>>(
   Component: ComponentType<P>,
   moduleUrl: string,
-): HydratableComponent<P>;
+): ClientComponent<P>;
 
 export interface IslandProps<P = Record<string, unknown>> {
-  component: HydratableComponent<P>;
+  component: ClientComponent<P>;
   /**
    * is-land initialization trigger. Common values: `"interaction"`, `"visible"`,
    * `"idle"`. Rendered as the boolean attribute `land-on:<on>` on the underlying
@@ -34,7 +33,11 @@ export function Island<P = Record<string, unknown>>(
   props: IslandProps<P>,
 ): VNode;
 
-/** @internal used by the plugin to install the URL resolver */
-export function _setHydrateModuleResolver(
+/**
+ * Install the client module URL resolver. Called by the Eleventy plugin during
+ * config setup. Also part of the public API for users who want to use `<Island>`
+ * without adopting this package's file naming / URL convention.
+ */
+export function setClientModuleResolver(
   resolver: (moduleUrl: string) => string,
 ): void;

--- a/packages/eleventy-plugin-preact-island/island.mjs
+++ b/packages/eleventy-plugin-preact-island/island.mjs
@@ -3,45 +3,46 @@ import { h } from "preact";
 let currentResolver = null;
 
 /**
- * Install the hydrate module URL resolver. Called by the Eleventy plugin during
- * config setup; not part of the public API.
- * @internal
+ * Install the client module URL resolver. Called by the Eleventy plugin during
+ * config setup. Also part of the public API for users who want to use `<Island>`
+ * without adopting this package's file naming / URL convention.
+ *
  * @param {(moduleUrl: string) => string} resolver
  */
-export function _setHydrateModuleResolver(resolver) {
+export function setClientModuleResolver(resolver) {
   currentResolver = resolver;
 }
 
 /**
- * Attach the SSR-side module URL as metadata to a hydration component.
- * Call this once in each `*.hydrate.jsx` file's default export.
+ * Attach the SSR-side module URL as metadata to a client component.
+ * Call this once in each `*.client.jsx` file's default export.
  *
  * @template {import("preact").ComponentType<any>} C
  * @param {C} Component
- * @param {string} moduleUrl Usually `import.meta.url` from the hydrate file.
+ * @param {string} moduleUrl Usually `import.meta.url` from the client file.
  * @returns {C}
  */
-export function hydratable(Component, moduleUrl) {
+export function clientComponent(Component, moduleUrl) {
   if (typeof Component !== "function") {
-    throw new TypeError("hydratable: `Component` must be a function");
+    throw new TypeError("clientComponent: `Component` must be a function");
   }
   if (typeof moduleUrl !== "string") {
     throw new TypeError(
-      "hydratable: `moduleUrl` must be a string (usually `import.meta.url`)",
+      "clientComponent: `moduleUrl` must be a string (usually `import.meta.url`)",
     );
   }
-  Component.__hydrateModuleUrl = moduleUrl;
+  Component.__clientModuleUrl = moduleUrl;
   return Component;
 }
 
 /**
  * Wrap a Preact component for Partial Hydration via is-land. The SSR output is
  * the component rendered with the same `props`, wrapped in `<is-land>` with the
- * hydration import URL derived from the injected resolver.
+ * client module import URL derived from the injected resolver.
  *
  * @param {Object} attrs
  * @param {import("preact").ComponentType<any>} attrs.component - Component
- *   wrapped with `hydratable()` in its `*.hydrate.jsx` file.
+ *   wrapped with `clientComponent()` in its `*.client.jsx` file.
  * @param {string} [attrs.on="interaction"] - is-land initialization trigger
  *   name (e.g. `"interaction"`, `"visible"`, `"idle"`).
  */
@@ -53,7 +54,7 @@ export function Island({ component, on = "interaction", ...props }) {
   delete props.children;
   if (typeof component !== "function") {
     throw new TypeError(
-      "Island: `component` prop must be a Preact component wrapped with `hydratable()`",
+      "Island: `component` prop must be a Preact component wrapped with `clientComponent()`",
     );
   }
   // Reject values that would produce a broken `land-on:*` attribute (whitespace,
@@ -64,15 +65,15 @@ export function Island({ component, on = "interaction", ...props }) {
       `Island: \`on\` must match /^[A-Za-z0-9_-]+$/ (e.g. "interaction", "visible", "idle"), got: ${JSON.stringify(on)}`,
     );
   }
-  const moduleUrl = component.__hydrateModuleUrl;
+  const moduleUrl = component.__clientModuleUrl;
   if (typeof moduleUrl !== "string") {
     throw new Error(
-      "Island: `component` is not marked as hydratable. Wrap the default export of your *.hydrate.jsx file with `hydratable(Component, import.meta.url)`.",
+      "Island: `component` is not marked as a client component. Wrap the default export of your *.client.jsx file with `clientComponent(Component, import.meta.url)`.",
     );
   }
   if (typeof currentResolver !== "function") {
     throw new Error(
-      "Island: no hydrate module URL resolver is configured. Ensure `@tuqulore-inc/eleventy-plugin-preact-island` is registered via `eleventyConfig.addPlugin`.",
+      "Island: no client module URL resolver is configured. Ensure `@tuqulore-inc/eleventy-plugin-preact-island` is registered via `eleventyConfig.addPlugin`, or call `setClientModuleResolver` directly.",
     );
   }
   const importUrl = currentResolver(moduleUrl);

--- a/packages/eleventy-plugin-preact-island/island.mjs
+++ b/packages/eleventy-plugin-preact-island/island.mjs
@@ -7,9 +7,17 @@ let currentResolver = null;
  * config setup. Also part of the public API for users who want to use `<Island>`
  * without adopting this package's file naming / URL convention.
  *
- * @param {(moduleUrl: string) => string} resolver
+ * Pass `null` to explicitly clear the currently installed resolver (used by
+ * tests to reset state between cases).
+ *
+ * @param {((moduleUrl: string) => string) | null} resolver
  */
 export function setClientModuleResolver(resolver) {
+  if (resolver !== null && typeof resolver !== "function") {
+    throw new TypeError(
+      `setClientModuleResolver: \`resolver\` must be a function or null, got ${typeof resolver}`,
+    );
+  }
   currentResolver = resolver;
 }
 

--- a/packages/eleventy-plugin-preact-island/island.mjs
+++ b/packages/eleventy-plugin-preact-island/island.mjs
@@ -3,19 +3,19 @@ import { h } from "preact";
 let currentResolver = null;
 
 /**
- * Install the client module URL resolver. Called by the Eleventy plugin during
- * config setup. Also part of the public API for users who want to use `<Island>`
- * without adopting this package's file naming / URL convention.
+ * Install the client module URL resolver. Wired by the Eleventy plugin during
+ * config setup; also called by tests to swap resolvers between cases.
  *
- * Pass `null` to explicitly clear the currently installed resolver (used by
- * tests to reset state between cases).
+ * Pass `null` to explicitly clear the currently installed resolver.
  *
+ * @internal Not part of the public API. Registering the plugin via
+ *   `eleventyConfig.addPlugin` wires the resolver for you.
  * @param {((moduleUrl: string) => string) | null} resolver
  */
-export function setClientModuleResolver(resolver) {
+export function _setClientModuleResolver(resolver) {
   if (resolver !== null && typeof resolver !== "function") {
     throw new TypeError(
-      `setClientModuleResolver: \`resolver\` must be a function or null, got ${typeof resolver}`,
+      `_setClientModuleResolver: \`resolver\` must be a function or null, got ${typeof resolver}`,
     );
   }
   currentResolver = resolver;
@@ -81,7 +81,7 @@ export function Island({ component, on = "interaction", ...props }) {
   }
   if (typeof currentResolver !== "function") {
     throw new Error(
-      "Island: no client module URL resolver is configured. Ensure `@tuqulore-inc/eleventy-plugin-preact-island` is registered via `eleventyConfig.addPlugin`, or call `setClientModuleResolver` directly.",
+      "Island: no client module URL resolver is configured. Register `@tuqulore-inc/eleventy-plugin-preact-island` via `eleventyConfig.addPlugin`.",
     );
   }
   const importUrl = currentResolver(moduleUrl);

--- a/packages/eleventy-plugin-preact-island/island.test.mjs
+++ b/packages/eleventy-plugin-preact-island/island.test.mjs
@@ -2,55 +2,55 @@ import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert";
 import { h } from "preact";
 import { render } from "preact-render-to-string";
-import { Island, hydratable, _setHydrateModuleResolver } from "./island.mjs";
+import { Island, clientComponent, setClientModuleResolver } from "./island.mjs";
 
-describe("hydratable", () => {
-  it("Component に __hydrateModuleUrl を付与して同じ関数を返す", () => {
+describe("clientComponent", () => {
+  it("Component に __clientModuleUrl を付与して同じ関数を返す", () => {
     const Comp = () => null;
-    const returned = hydratable(Comp, "file:///proj/src/foo.hydrate.jsx");
+    const returned = clientComponent(Comp, "file:///proj/src/foo.client.jsx");
     assert.strictEqual(returned, Comp);
     assert.strictEqual(
-      Comp.__hydrateModuleUrl,
-      "file:///proj/src/foo.hydrate.jsx",
+      Comp.__clientModuleUrl,
+      "file:///proj/src/foo.client.jsx",
     );
   });
 
   it("Component が関数でない場合は TypeError", () => {
-    assert.throws(() => hydratable(null, "file:///x"), TypeError);
-    assert.throws(() => hydratable("Comp", "file:///x"), TypeError);
+    assert.throws(() => clientComponent(null, "file:///x"), TypeError);
+    assert.throws(() => clientComponent("Comp", "file:///x"), TypeError);
   });
 
   it("moduleUrl が文字列でない場合は TypeError", () => {
-    assert.throws(() => hydratable(() => null, undefined), TypeError);
-    assert.throws(() => hydratable(() => null, 123), TypeError);
+    assert.throws(() => clientComponent(() => null, undefined), TypeError);
+    assert.throws(() => clientComponent(() => null, 123), TypeError);
   });
 });
 
 describe("Island", () => {
   beforeEach(() => {
     // 各テストで resolver をリセットし、テスト間の状態漏れを防ぐ
-    _setHydrateModuleResolver(null);
+    setClientModuleResolver(null);
   });
 
-  it("hydratable 済み component を <is-land> でラップし、resolver 経由の import URL と JSON props を出力する", () => {
+  it("clientComponent 済み component を <is-land> でラップし、resolver 経由の import URL と JSON props を出力する", () => {
     const receivedUrls = [];
-    _setHydrateModuleResolver((moduleUrl) => {
+    setClientModuleResolver((moduleUrl) => {
       receivedUrls.push(moduleUrl);
-      return "/foo.hydrate.js";
+      return "/foo.client.js";
     });
-    const Foo = hydratable(function Foo(props) {
+    const Foo = clientComponent(function Foo(props) {
       return h("span", null, props.name);
-    }, "file:///proj/src/foo.hydrate.jsx");
+    }, "file:///proj/src/foo.client.jsx");
 
     const html = render(
       h(Island, { component: Foo, on: "visible", name: "alice" }),
     );
 
-    assert.deepStrictEqual(receivedUrls, ["file:///proj/src/foo.hydrate.jsx"]);
+    assert.deepStrictEqual(receivedUrls, ["file:///proj/src/foo.client.jsx"]);
     assert.match(html, /^<is-land/);
     assert.match(html, /land-on:visible/);
     assert.match(html, /type="preact"/);
-    assert.match(html, /import="\/foo\.hydrate\.js"/);
+    assert.match(html, /import="\/foo\.client\.js"/);
     // JSON.stringify({ name: "alice" }) が HTML エスケープされて属性値に入る
     assert.match(html, /props="\{&quot;name&quot;:&quot;alice&quot;\}"/);
     // SSR 内容として component が同じ props でレンダリングされている
@@ -59,14 +59,14 @@ describe("Island", () => {
   });
 
   it("on prop のデフォルトは interaction", () => {
-    _setHydrateModuleResolver(() => "/x.hydrate.js");
-    const X = hydratable(() => null, "file:///proj/src/x.hydrate.jsx");
+    setClientModuleResolver(() => "/x.client.js");
+    const X = clientComponent(() => null, "file:///proj/src/x.client.jsx");
     const html = render(h(Island, { component: X }));
     assert.match(html, /land-on:interaction/);
   });
 
   it("component が渡されていない (または関数でない) 場合は TypeError", () => {
-    _setHydrateModuleResolver(() => "/x.hydrate.js");
+    setClientModuleResolver(() => "/x.client.js");
     assert.throws(
       () => render(h(Island, { component: "not-a-fn" })),
       TypeError,
@@ -74,8 +74,8 @@ describe("Island", () => {
   });
 
   it("on に不正な値 (空白 / 空文字 / 非文字列) を渡すと TypeError", () => {
-    _setHydrateModuleResolver(() => "/x.hydrate.js");
-    const X = hydratable(() => null, "file:///proj/src/x.hydrate.jsx");
+    setClientModuleResolver(() => "/x.client.js");
+    const X = clientComponent(() => null, "file:///proj/src/x.client.jsx");
     for (const on of ["foo bar", "", 'bad"quote', 123, null]) {
       assert.throws(
         () => render(h(Island, { component: X, on })),
@@ -86,28 +86,28 @@ describe("Island", () => {
     }
   });
 
-  it("component が hydratable でラップされていない場合は明示エラー", () => {
-    _setHydrateModuleResolver(() => "/x.hydrate.js");
+  it("component が clientComponent でラップされていない場合は明示エラー", () => {
+    setClientModuleResolver(() => "/x.client.js");
     const Bare = () => null;
     assert.throws(
       () => render(h(Island, { component: Bare })),
-      /not marked as hydratable/,
+      /not marked as a client component/,
     );
   });
 
   it("resolver が未設定の場合は明示エラー", () => {
-    const X = hydratable(() => null, "file:///proj/src/x.hydrate.jsx");
+    const X = clientComponent(() => null, "file:///proj/src/x.client.jsx");
     assert.throws(
       () => render(h(Island, { component: X })),
-      /no hydrate module URL resolver is configured/,
+      /no client module URL resolver is configured/,
     );
   });
 
   it("children を渡しても component の SSR 出力が優先される (呼び出し側は component だけ渡せば済む)", () => {
-    _setHydrateModuleResolver(() => "/x.hydrate.js");
-    const X = hydratable(function X(props) {
+    setClientModuleResolver(() => "/x.client.js");
+    const X = clientComponent(function X(props) {
       return h("i", null, `x-${props.tag}`);
-    }, "file:///proj/src/x.hydrate.jsx");
+    }, "file:///proj/src/x.client.jsx");
     const html = render(
       h(Island, { component: X, tag: "auto" }, h("b", null, "ignored")),
     );
@@ -116,12 +116,12 @@ describe("Island", () => {
   });
 
   it("children は props シリアライズにもコンポーネント SSR にも漏れない", () => {
-    _setHydrateModuleResolver(() => "/x.hydrate.js");
+    setClientModuleResolver(() => "/x.client.js");
     const receivedProps = [];
-    const X = hydratable(function X(props) {
+    const X = clientComponent(function X(props) {
       receivedProps.push(props);
       return h("i", null, `x-${props.tag}`);
-    }, "file:///proj/src/x.hydrate.jsx");
+    }, "file:///proj/src/x.client.jsx");
 
     const html = render(
       h(Island, { component: X, tag: "auto" }, h("b", null, "ignored")),
@@ -135,10 +135,10 @@ describe("Island", () => {
   });
 
   it("JSON.stringify に失敗する props (循環参照など) は Island 文脈のエラーで包む", () => {
-    _setHydrateModuleResolver(() => "/x.hydrate.js");
-    const X = hydratable(function X() {
+    setClientModuleResolver(() => "/x.client.js");
+    const X = clientComponent(function X() {
       return null;
-    }, "file:///proj/src/x.hydrate.jsx");
+    }, "file:///proj/src/x.client.jsx");
 
     const circular = {};
     circular.self = circular;
@@ -147,7 +147,7 @@ describe("Island", () => {
       () => render(h(Island, { component: X, data: circular })),
       (err) => {
         assert.match(err.message, /Island: failed to JSON\.stringify props/);
-        assert.match(err.message, /\/x\.hydrate\.js/);
+        assert.match(err.message, /\/x\.client\.js/);
         assert.ok(
           err.cause instanceof TypeError,
           "元の TypeError が cause に保持されている",

--- a/packages/eleventy-plugin-preact-island/island.test.mjs
+++ b/packages/eleventy-plugin-preact-island/island.test.mjs
@@ -4,6 +4,31 @@ import { h } from "preact";
 import { render } from "preact-render-to-string";
 import { Island, clientComponent, setClientModuleResolver } from "./island.mjs";
 
+describe("setClientModuleResolver", () => {
+  it("関数を渡せる", () => {
+    assert.doesNotThrow(() => setClientModuleResolver(() => "/x.js"));
+    // 状態を残さない: 後続テストの beforeEach で null リセットされるが念のため
+    setClientModuleResolver(null);
+  });
+
+  it("null で明示的にクリアできる", () => {
+    setClientModuleResolver(() => "/x.js");
+    assert.doesNotThrow(() => setClientModuleResolver(null));
+  });
+
+  it("関数でも null でもない値は TypeError で拒否する", () => {
+    for (const bad of [undefined, 0, "string", {}, [], true]) {
+      assert.throws(
+        () => setClientModuleResolver(bad),
+        (err) =>
+          err instanceof TypeError &&
+          /`resolver` must be a function or null/.test(err.message),
+        `setClientModuleResolver(${JSON.stringify(bad)}) が TypeError にならなかった`,
+      );
+    }
+  });
+});
+
 describe("clientComponent", () => {
   it("Component に __clientModuleUrl を付与して同じ関数を返す", () => {
     const Comp = () => null;

--- a/packages/eleventy-plugin-preact-island/island.test.mjs
+++ b/packages/eleventy-plugin-preact-island/island.test.mjs
@@ -2,28 +2,32 @@ import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert";
 import { h } from "preact";
 import { render } from "preact-render-to-string";
-import { Island, clientComponent, setClientModuleResolver } from "./island.mjs";
+import {
+  Island,
+  clientComponent,
+  _setClientModuleResolver,
+} from "./island.mjs";
 
-describe("setClientModuleResolver", () => {
+describe("_setClientModuleResolver", () => {
   it("関数を渡せる", () => {
-    assert.doesNotThrow(() => setClientModuleResolver(() => "/x.js"));
+    assert.doesNotThrow(() => _setClientModuleResolver(() => "/x.js"));
     // 状態を残さない: 後続テストの beforeEach で null リセットされるが念のため
-    setClientModuleResolver(null);
+    _setClientModuleResolver(null);
   });
 
   it("null で明示的にクリアできる", () => {
-    setClientModuleResolver(() => "/x.js");
-    assert.doesNotThrow(() => setClientModuleResolver(null));
+    _setClientModuleResolver(() => "/x.js");
+    assert.doesNotThrow(() => _setClientModuleResolver(null));
   });
 
   it("関数でも null でもない値は TypeError で拒否する", () => {
     for (const bad of [undefined, 0, "string", {}, [], true]) {
       assert.throws(
-        () => setClientModuleResolver(bad),
+        () => _setClientModuleResolver(bad),
         (err) =>
           err instanceof TypeError &&
           /`resolver` must be a function or null/.test(err.message),
-        `setClientModuleResolver(${JSON.stringify(bad)}) が TypeError にならなかった`,
+        `_setClientModuleResolver(${JSON.stringify(bad)}) が TypeError にならなかった`,
       );
     }
   });
@@ -54,12 +58,12 @@ describe("clientComponent", () => {
 describe("Island", () => {
   beforeEach(() => {
     // 各テストで resolver をリセットし、テスト間の状態漏れを防ぐ
-    setClientModuleResolver(null);
+    _setClientModuleResolver(null);
   });
 
   it("clientComponent 済み component を <is-land> でラップし、resolver 経由の import URL と JSON props を出力する", () => {
     const receivedUrls = [];
-    setClientModuleResolver((moduleUrl) => {
+    _setClientModuleResolver((moduleUrl) => {
       receivedUrls.push(moduleUrl);
       return "/foo.client.js";
     });
@@ -84,14 +88,14 @@ describe("Island", () => {
   });
 
   it("on prop のデフォルトは interaction", () => {
-    setClientModuleResolver(() => "/x.client.js");
+    _setClientModuleResolver(() => "/x.client.js");
     const X = clientComponent(() => null, "file:///proj/src/x.client.jsx");
     const html = render(h(Island, { component: X }));
     assert.match(html, /land-on:interaction/);
   });
 
   it("component が渡されていない (または関数でない) 場合は TypeError", () => {
-    setClientModuleResolver(() => "/x.client.js");
+    _setClientModuleResolver(() => "/x.client.js");
     assert.throws(
       () => render(h(Island, { component: "not-a-fn" })),
       TypeError,
@@ -99,7 +103,7 @@ describe("Island", () => {
   });
 
   it("on に不正な値 (空白 / 空文字 / 非文字列) を渡すと TypeError", () => {
-    setClientModuleResolver(() => "/x.client.js");
+    _setClientModuleResolver(() => "/x.client.js");
     const X = clientComponent(() => null, "file:///proj/src/x.client.jsx");
     for (const on of ["foo bar", "", 'bad"quote', 123, null]) {
       assert.throws(
@@ -112,7 +116,7 @@ describe("Island", () => {
   });
 
   it("component が clientComponent でラップされていない場合は明示エラー", () => {
-    setClientModuleResolver(() => "/x.client.js");
+    _setClientModuleResolver(() => "/x.client.js");
     const Bare = () => null;
     assert.throws(
       () => render(h(Island, { component: Bare })),
@@ -129,7 +133,7 @@ describe("Island", () => {
   });
 
   it("children を渡しても component の SSR 出力が優先される (呼び出し側は component だけ渡せば済む)", () => {
-    setClientModuleResolver(() => "/x.client.js");
+    _setClientModuleResolver(() => "/x.client.js");
     const X = clientComponent(function X(props) {
       return h("i", null, `x-${props.tag}`);
     }, "file:///proj/src/x.client.jsx");
@@ -141,7 +145,7 @@ describe("Island", () => {
   });
 
   it("children は props シリアライズにもコンポーネント SSR にも漏れない", () => {
-    setClientModuleResolver(() => "/x.client.js");
+    _setClientModuleResolver(() => "/x.client.js");
     const receivedProps = [];
     const X = clientComponent(function X(props) {
       receivedProps.push(props);
@@ -160,7 +164,7 @@ describe("Island", () => {
   });
 
   it("JSON.stringify に失敗する props (循環参照など) は Island 文脈のエラーで包む", () => {
-    setClientModuleResolver(() => "/x.client.js");
+    _setClientModuleResolver(() => "/x.client.js");
     const X = clientComponent(function X() {
       return null;
     }, "file:///proj/src/x.client.jsx");

--- a/packages/eleventy-plugin-preact-island/package.json
+++ b/packages/eleventy-plugin-preact-island/package.json
@@ -25,10 +25,6 @@
     "./island": {
       "types": "./island.d.ts",
       "default": "./island.mjs"
-    },
-    "./resolver": {
-      "types": "./resolver.d.ts",
-      "default": "./resolver.mjs"
     }
   },
   "main": "./index.mjs",
@@ -47,7 +43,8 @@
   },
   "dependencies": {
     "@11ty/is-land": "^5.0.0",
-    "esbuild": "^0.28.0"
+    "esbuild": "^0.28.0",
+    "fast-glob": "^3.3.3"
   },
   "devDependencies": {
     "@tuqulore-inc/eslint-config": "workspace:*",

--- a/packages/eleventy-plugin-preact-island/package.json
+++ b/packages/eleventy-plugin-preact-island/package.json
@@ -46,7 +46,8 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@11ty/is-land": "^5.0.0"
+    "@11ty/is-land": "^5.0.0",
+    "esbuild": "^0.28.0"
   },
   "devDependencies": {
     "@tuqulore-inc/eslint-config": "workspace:*",

--- a/packages/eleventy-plugin-preact-island/resolver.d.ts
+++ b/packages/eleventy-plugin-preact-island/resolver.d.ts
@@ -1,9 +1,10 @@
 export interface CreateClientModuleResolverOptions {
   /**
-   * Input directory that matches the Eleventy input directory / esbuild `outbase`.
-   * @default "src"
+   * Eleventy input directory (e.g. `eleventyConfig.directories.input`, `"./src/"`).
+   * Resolved to an absolute path; a client module URL must fall under it.
+   * @default "."
    */
-  srcDir?: string;
+  inputDir?: string;
   /**
    * URL path prefix where the compiled client module bundles are served.
    * @default "/"
@@ -17,6 +18,8 @@ export type ClientModuleResolver = (moduleUrl: string) => string;
  * Create a resolver that converts an SSR-side client module URL
  * (e.g. `import.meta.url` inside `foo.client.jsx`) into the browser URL
  * where the compiled bundle will be served.
+ *
+ * @internal Wired by the Eleventy plugin; not part of the public API.
  */
 export function createClientModuleResolver(
   options?: CreateClientModuleResolverOptions,

--- a/packages/eleventy-plugin-preact-island/resolver.d.ts
+++ b/packages/eleventy-plugin-preact-island/resolver.d.ts
@@ -1,23 +1,23 @@
-export interface CreateHydrateModuleResolverOptions {
+export interface CreateClientModuleResolverOptions {
   /**
    * Input directory that matches the Eleventy input directory / esbuild `outbase`.
    * @default "src"
    */
   srcDir?: string;
   /**
-   * URL path prefix where the compiled hydrate bundles are served.
+   * URL path prefix where the compiled client module bundles are served.
    * @default "/"
    */
   urlPrefix?: string;
 }
 
-export type HydrateModuleResolver = (moduleUrl: string) => string;
+export type ClientModuleResolver = (moduleUrl: string) => string;
 
 /**
- * Create a resolver that converts an SSR-side hydrate module URL
- * (e.g. `import.meta.url` inside `foo.hydrate.jsx`) into the browser URL
+ * Create a resolver that converts an SSR-side client module URL
+ * (e.g. `import.meta.url` inside `foo.client.jsx`) into the browser URL
  * where the compiled bundle will be served.
  */
-export function createHydrateModuleResolver(
-  options?: CreateHydrateModuleResolverOptions,
-): HydrateModuleResolver;
+export function createClientModuleResolver(
+  options?: CreateClientModuleResolverOptions,
+): ClientModuleResolver;

--- a/packages/eleventy-plugin-preact-island/resolver.mjs
+++ b/packages/eleventy-plugin-preact-island/resolver.mjs
@@ -1,10 +1,10 @@
 /**
- * Create a resolver that converts an SSR-side hydrate module URL
- * (e.g. `import.meta.url` inside `foo.hydrate.jsx`) into the browser URL
+ * Create a resolver that converts an SSR-side client module URL
+ * (e.g. `import.meta.url` inside `foo.client.jsx`) into the browser URL
  * where the compiled bundle will be served.
  *
  * Convention (customizable via options):
- *   `<srcDir>/<sub>.hydrate.{jsx,tsx,js,ts}` → `<urlPrefix><sub>.hydrate.js`
+ *   `<srcDir>/<sub>.client.{jsx,tsx,js,ts}` → `<urlPrefix><sub>.client.js`
  *
  * @param {Object} [options]
  * @param {string} [options.srcDir="src"] Input directory that matches the
@@ -13,31 +13,31 @@
  *   bundles are served.
  * @returns {(moduleUrl: string) => string}
  */
-export function createHydrateModuleResolver({
+export function createClientModuleResolver({
   srcDir = "src",
   urlPrefix = "/",
 } = {}) {
   if (typeof srcDir !== "string") {
     throw new TypeError(
-      "createHydrateModuleResolver: `srcDir` must be a string",
+      "createClientModuleResolver: `srcDir` must be a string",
     );
   }
   if (typeof urlPrefix !== "string") {
     throw new TypeError(
-      "createHydrateModuleResolver: `urlPrefix` must be a string",
+      "createClientModuleResolver: `urlPrefix` must be a string",
     );
   }
 
   const normalizedSrcDir = srcDir.replace(/^\/+|\/+$/g, "");
   if (normalizedSrcDir.length === 0) {
     throw new TypeError(
-      "createHydrateModuleResolver: `srcDir` must contain at least one path segment",
+      "createClientModuleResolver: `srcDir` must contain at least one path segment",
     );
   }
   const marker = `/${normalizedSrcDir}/`;
   const normalizedPrefix = normalizeUrlPrefix(urlPrefix);
 
-  return function resolveHydrateModuleUrl(moduleUrl) {
+  return function resolveClientModuleUrl(moduleUrl) {
     let pathname;
     try {
       // Keep the pathname URL-encoded so the resulting browser URL stays a
@@ -52,18 +52,18 @@ export function createHydrateModuleResolver({
     const idx = pathname.lastIndexOf(marker);
     if (idx === -1) {
       throw new Error(
-        `[eleventy-plugin-preact-island] Hydrate module must live under "${normalizedSrcDir}/": ${pathname}`,
+        `[eleventy-plugin-preact-island] Client module must live under "${normalizedSrcDir}/": ${pathname}`,
       );
     }
 
     const rest = pathname.slice(idx + marker.length);
-    const match = rest.match(/^(.+)\.hydrate\.(?:jsx|tsx|js|ts)$/);
+    const match = rest.match(/^(.+)\.client\.(?:jsx|tsx|js|ts)$/);
     if (!match) {
       throw new Error(
-        `[eleventy-plugin-preact-island] Hydrate module must end with .hydrate.{js,jsx,ts,tsx}: ${pathname}`,
+        `[eleventy-plugin-preact-island] Client module must end with .client.{js,jsx,ts,tsx}: ${pathname}`,
       );
     }
-    return `${normalizedPrefix}${match[1]}.hydrate.js`;
+    return `${normalizedPrefix}${match[1]}.client.js`;
   };
 }
 

--- a/packages/eleventy-plugin-preact-island/resolver.mjs
+++ b/packages/eleventy-plugin-preact-island/resolver.mjs
@@ -1,25 +1,30 @@
+import path from "node:path";
+import url from "node:url";
+
 /**
  * Create a resolver that converts an SSR-side client module URL
  * (e.g. `import.meta.url` inside `foo.client.jsx`) into the browser URL
  * where the compiled bundle will be served.
  *
- * Convention (customizable via options):
- *   `<srcDir>/<sub>.client.{jsx,tsx,js,ts}` → `<urlPrefix><sub>.client.js`
+ * Convention:
+ *   `<inputDir>/<sub>.client.{jsx,tsx,js,ts}` → `<urlPrefix><sub>.client.js`
  *
+ * @internal Wired by the Eleventy plugin; not part of the public API.
  * @param {Object} [options]
- * @param {string} [options.srcDir="src"] Input directory that matches the
- *   Eleventy input directory / esbuild `outbase`.
+ * @param {string} [options.inputDir="."] Eleventy input directory (e.g.
+ *   `eleventyConfig.directories.input`, `"./src/"`). Resolved to an absolute
+ *   path; a client module URL must fall under it.
  * @param {string} [options.urlPrefix="/"] URL path prefix where the compiled
- *   bundles are served.
+ *   bundles are served (follows Eleventy `pathPrefix`).
  * @returns {(moduleUrl: string) => string}
  */
 export function createClientModuleResolver({
-  srcDir = "src",
+  inputDir = ".",
   urlPrefix = "/",
 } = {}) {
-  if (typeof srcDir !== "string") {
+  if (typeof inputDir !== "string") {
     throw new TypeError(
-      "createClientModuleResolver: `srcDir` must be a string",
+      "createClientModuleResolver: `inputDir` must be a string",
     );
   }
   if (typeof urlPrefix !== "string") {
@@ -28,20 +33,19 @@ export function createClientModuleResolver({
     );
   }
 
-  const normalizedSrcDir = srcDir.replace(/^\/+|\/+$/g, "");
-  if (normalizedSrcDir.length === 0) {
-    throw new TypeError(
-      "createClientModuleResolver: `srcDir` must contain at least one path segment",
-    );
-  }
-  const marker = `/${normalizedSrcDir}/`;
+  // Absolute input dir as a URL pathname, with a guaranteed trailing slash so
+  // prefix matching can't leak across sibling dirs (`/src` vs `/src-review/`).
+  // NOTE: compare against `new URL(moduleUrl).pathname` (not a decoded fs path)
+  // so both sides stay percent-encoded and the emitted URL remains a valid
+  // module specifier (a space stays `%20`, never a literal space).
+  let inputBase = url.pathToFileURL(path.resolve(inputDir)).pathname;
+  if (!inputBase.endsWith("/")) inputBase += "/";
+
   const normalizedPrefix = normalizeUrlPrefix(urlPrefix);
 
   return function resolveClientModuleUrl(moduleUrl) {
     let pathname;
     try {
-      // Keep the pathname URL-encoded so the resulting browser URL stays a
-      // valid module specifier (e.g. spaces remain `%20`, not literal spaces).
       pathname = new URL(moduleUrl).pathname;
     } catch {
       throw new Error(
@@ -49,14 +53,13 @@ export function createClientModuleResolver({
       );
     }
 
-    const idx = pathname.lastIndexOf(marker);
-    if (idx === -1) {
+    if (!pathname.startsWith(inputBase)) {
       throw new Error(
-        `[eleventy-plugin-preact-island] Client module must live under "${normalizedSrcDir}/": ${pathname}`,
+        `[eleventy-plugin-preact-island] Client module must live under the Eleventy input directory (${inputBase}): ${pathname}`,
       );
     }
 
-    const rest = pathname.slice(idx + marker.length);
+    const rest = pathname.slice(inputBase.length);
     const match = rest.match(/^(.+)\.client\.(?:jsx|tsx|js|ts)$/);
     if (!match) {
       throw new Error(
@@ -67,7 +70,15 @@ export function createClientModuleResolver({
   };
 }
 
-function normalizeUrlPrefix(prefix) {
+/**
+ * Ensure a URL path prefix has both leading and trailing slashes.
+ *
+ * @internal Shared with the plugin so the injected importmap and the resolved
+ *   client module URLs agree on the same prefix.
+ * @param {string} prefix
+ * @returns {string}
+ */
+export function normalizeUrlPrefix(prefix) {
   let p = prefix;
   if (!p.startsWith("/")) p = `/${p}`;
   if (!p.endsWith("/")) p = `${p}/`;

--- a/packages/eleventy-plugin-preact-island/resolver.test.mjs
+++ b/packages/eleventy-plugin-preact-island/resolver.test.mjs
@@ -1,19 +1,25 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
+import path from "node:path";
+import url from "node:url";
 import { createClientModuleResolver } from "./resolver.mjs";
 
+// Absolute inputDir values keep tests independent of the runner's cwd (the
+// resolver `path.resolve`s inputDir, so module URLs must fall under the
+// resolved absolute base).
+
 describe("createClientModuleResolver", () => {
-  describe("デフォルト設定", () => {
-    it("srcDir=src, urlPrefix=/ で src/**/*.client.jsx を /**/client.js に変換する", () => {
-      const resolve = createClientModuleResolver();
+  describe("input 配下のモジュールを解決する", () => {
+    it("ネストしたモジュールを <urlPrefix><sub>.client.js に変換する", () => {
+      const resolve = createClientModuleResolver({ inputDir: "/proj/src" });
       assert.strictEqual(
-        resolve("file:///home/user/proj/src/foo/bar.client.jsx"),
+        resolve("file:///proj/src/foo/bar.client.jsx"),
         "/foo/bar.client.js",
       );
     });
 
     it(".jsx / .tsx / .js / .ts を全て受け付け .client.js に統一する", () => {
-      const resolve = createClientModuleResolver();
+      const resolve = createClientModuleResolver({ inputDir: "/proj/src" });
       for (const ext of ["jsx", "tsx", "js", "ts"]) {
         assert.strictEqual(
           resolve(`file:///proj/src/foo.client.${ext}`),
@@ -21,19 +27,30 @@ describe("createClientModuleResolver", () => {
         );
       }
     });
-  });
 
-  describe("カスタム srcDir / urlPrefix", () => {
-    it("カスタム srcDir に従う", () => {
-      const resolve = createClientModuleResolver({ srcDir: "content" });
+    it('input "." (Eleventy デフォルト = プロジェクトルート) 直下も解決する', () => {
+      const resolve = createClientModuleResolver({ inputDir: "." });
+      const moduleUrl = url.pathToFileURL(
+        path.join(process.cwd(), "foo.client.jsx"),
+      ).href;
+      assert.strictEqual(resolve(moduleUrl), "/foo.client.js");
+    });
+
+    it('input "./src/" 形式 (末尾スラッシュ) でも解決する', () => {
+      const resolve = createClientModuleResolver({ inputDir: "/proj/src/" });
       assert.strictEqual(
-        resolve("file:///proj/content/foo.client.jsx"),
+        resolve("file:///proj/src/foo.client.jsx"),
         "/foo.client.js",
       );
     });
+  });
 
+  describe("urlPrefix", () => {
     it("カスタム urlPrefix を先頭に付ける", () => {
-      const resolve = createClientModuleResolver({ urlPrefix: "/assets" });
+      const resolve = createClientModuleResolver({
+        inputDir: "/proj/src",
+        urlPrefix: "/assets",
+      });
       assert.strictEqual(
         resolve("file:///proj/src/foo.client.jsx"),
         "/assets/foo.client.js",
@@ -41,25 +58,15 @@ describe("createClientModuleResolver", () => {
     });
 
     it("urlPrefix の前後スラッシュを正規化する", () => {
-      const cases = ["assets", "/assets", "assets/", "/assets/"];
-      for (const urlPrefix of cases) {
-        const resolve = createClientModuleResolver({ urlPrefix });
+      for (const urlPrefix of ["assets", "/assets", "assets/", "/assets/"]) {
+        const resolve = createClientModuleResolver({
+          inputDir: "/proj/src",
+          urlPrefix,
+        });
         assert.strictEqual(
           resolve("file:///proj/src/foo.client.jsx"),
           "/assets/foo.client.js",
           `urlPrefix=${JSON.stringify(urlPrefix)} の正規化が不正`,
-        );
-      }
-    });
-
-    it("srcDir の前後スラッシュを正規化する", () => {
-      const cases = ["src", "/src", "src/", "/src/"];
-      for (const srcDir of cases) {
-        const resolve = createClientModuleResolver({ srcDir });
-        assert.strictEqual(
-          resolve("file:///proj/src/foo.client.jsx"),
-          "/foo.client.js",
-          `srcDir=${JSON.stringify(srcDir)} の正規化が不正`,
         );
       }
     });
@@ -69,33 +76,44 @@ describe("createClientModuleResolver", () => {
     it("URL エンコードされたパス (空白など) はエンコード形のまま維持する", () => {
       // browser の import() が specifier として直接使うため、literal space に
       // decode してはならない
-      const resolve = createClientModuleResolver();
+      const resolve = createClientModuleResolver({ inputDir: "/proj/src" });
       assert.strictEqual(
         resolve("file:///proj/src/with%20space/foo.client.jsx"),
         "/with%20space/foo.client.js",
       );
     });
-
-    it("経路の途中に src と紛らわしい名前 (src-review など) があっても最後の /src/ を採用する", () => {
-      const resolve = createClientModuleResolver();
-      assert.strictEqual(
-        resolve("file:///Users/x/src-review/src/foo.client.jsx"),
-        "/foo.client.js",
-      );
-    });
   });
 
-  describe("エラー", () => {
-    it("srcDir 配下にないモジュールは判別可能なエラーで失敗する", () => {
-      const resolve = createClientModuleResolver();
+  describe("エラー / 前方一致による偽マッチ排除", () => {
+    it("input ディレクトリ配下にないモジュールは判別可能なエラーで失敗する", () => {
+      const resolve = createClientModuleResolver({ inputDir: "/proj/src" });
       assert.throws(
         () => resolve("file:///proj/content/foo.client.jsx"),
-        /must live under "src\/"/,
+        /must live under the Eleventy input directory/,
+      );
+    });
+
+    it("node_modules 配下の紛らわしい .client.jsx は解決しない (回帰)", () => {
+      // 旧 marker 方式は部分一致 `/src/` で
+      // node_modules/pkg/src/foo.client.jsx に偽マッチしていた。絶対 input 前方一致では
+      // input(/proj/src) の外なので確実に弾く。
+      const resolve = createClientModuleResolver({ inputDir: "/proj/src" });
+      assert.throws(
+        () => resolve("file:///proj/node_modules/pkg/src/foo.client.jsx"),
+        /must live under the Eleventy input directory/,
+      );
+    });
+
+    it("兄弟ディレクトリ (src-review など) は末尾スラッシュ前方一致で弾く", () => {
+      const resolve = createClientModuleResolver({ inputDir: "/proj/src" });
+      assert.throws(
+        () => resolve("file:///proj/src-review/foo.client.jsx"),
+        /must live under the Eleventy input directory/,
       );
     });
 
     it(".client.{js,jsx,ts,tsx} 以外はエラーで失敗する", () => {
-      const resolve = createClientModuleResolver();
+      const resolve = createClientModuleResolver({ inputDir: "/proj/src" });
       assert.throws(
         () => resolve("file:///proj/src/foo.jsx"),
         /must end with \.client/,
@@ -103,27 +121,21 @@ describe("createClientModuleResolver", () => {
     });
 
     it("URL として不正な値はエラーで失敗する", () => {
-      const resolve = createClientModuleResolver();
+      const resolve = createClientModuleResolver({ inputDir: "/proj/src" });
       assert.throws(() => resolve("not-a-url"), /Invalid module URL/);
     });
 
-    it("srcDir が空文字列だと factory 呼び出しの時点で TypeError", () => {
+    it("inputDir が非文字列だと factory 呼び出しの時点で TypeError", () => {
       assert.throws(
-        () => createClientModuleResolver({ srcDir: "" }),
-        TypeError,
-      );
-    });
-
-    it("srcDir が非文字列だと factory 呼び出しの時点で TypeError", () => {
-      assert.throws(
-        () => createClientModuleResolver({ srcDir: 123 }),
+        () => createClientModuleResolver({ inputDir: 123 }),
         TypeError,
       );
     });
 
     it("urlPrefix が非文字列だと factory 呼び出しの時点で TypeError", () => {
       assert.throws(
-        () => createClientModuleResolver({ urlPrefix: 123 }),
+        () =>
+          createClientModuleResolver({ inputDir: "/proj/src", urlPrefix: 123 }),
         TypeError,
       );
     });

--- a/packages/eleventy-plugin-preact-island/resolver.test.mjs
+++ b/packages/eleventy-plugin-preact-island/resolver.test.mjs
@@ -1,23 +1,23 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { createHydrateModuleResolver } from "./resolver.mjs";
+import { createClientModuleResolver } from "./resolver.mjs";
 
-describe("createHydrateModuleResolver", () => {
+describe("createClientModuleResolver", () => {
   describe("デフォルト設定", () => {
-    it("srcDir=src, urlPrefix=/ で src/**/*.hydrate.jsx を /**/hydrate.js に変換する", () => {
-      const resolve = createHydrateModuleResolver();
+    it("srcDir=src, urlPrefix=/ で src/**/*.client.jsx を /**/client.js に変換する", () => {
+      const resolve = createClientModuleResolver();
       assert.strictEqual(
-        resolve("file:///home/user/proj/src/foo/bar.hydrate.jsx"),
-        "/foo/bar.hydrate.js",
+        resolve("file:///home/user/proj/src/foo/bar.client.jsx"),
+        "/foo/bar.client.js",
       );
     });
 
-    it(".jsx / .tsx / .js / .ts を全て受け付け .hydrate.js に統一する", () => {
-      const resolve = createHydrateModuleResolver();
+    it(".jsx / .tsx / .js / .ts を全て受け付け .client.js に統一する", () => {
+      const resolve = createClientModuleResolver();
       for (const ext of ["jsx", "tsx", "js", "ts"]) {
         assert.strictEqual(
-          resolve(`file:///proj/src/foo.hydrate.${ext}`),
-          "/foo.hydrate.js",
+          resolve(`file:///proj/src/foo.client.${ext}`),
+          "/foo.client.js",
         );
       }
     });
@@ -25,28 +25,28 @@ describe("createHydrateModuleResolver", () => {
 
   describe("カスタム srcDir / urlPrefix", () => {
     it("カスタム srcDir に従う", () => {
-      const resolve = createHydrateModuleResolver({ srcDir: "content" });
+      const resolve = createClientModuleResolver({ srcDir: "content" });
       assert.strictEqual(
-        resolve("file:///proj/content/foo.hydrate.jsx"),
-        "/foo.hydrate.js",
+        resolve("file:///proj/content/foo.client.jsx"),
+        "/foo.client.js",
       );
     });
 
     it("カスタム urlPrefix を先頭に付ける", () => {
-      const resolve = createHydrateModuleResolver({ urlPrefix: "/assets" });
+      const resolve = createClientModuleResolver({ urlPrefix: "/assets" });
       assert.strictEqual(
-        resolve("file:///proj/src/foo.hydrate.jsx"),
-        "/assets/foo.hydrate.js",
+        resolve("file:///proj/src/foo.client.jsx"),
+        "/assets/foo.client.js",
       );
     });
 
     it("urlPrefix の前後スラッシュを正規化する", () => {
       const cases = ["assets", "/assets", "assets/", "/assets/"];
       for (const urlPrefix of cases) {
-        const resolve = createHydrateModuleResolver({ urlPrefix });
+        const resolve = createClientModuleResolver({ urlPrefix });
         assert.strictEqual(
-          resolve("file:///proj/src/foo.hydrate.jsx"),
-          "/assets/foo.hydrate.js",
+          resolve("file:///proj/src/foo.client.jsx"),
+          "/assets/foo.client.js",
           `urlPrefix=${JSON.stringify(urlPrefix)} の正規化が不正`,
         );
       }
@@ -55,10 +55,10 @@ describe("createHydrateModuleResolver", () => {
     it("srcDir の前後スラッシュを正規化する", () => {
       const cases = ["src", "/src", "src/", "/src/"];
       for (const srcDir of cases) {
-        const resolve = createHydrateModuleResolver({ srcDir });
+        const resolve = createClientModuleResolver({ srcDir });
         assert.strictEqual(
-          resolve("file:///proj/src/foo.hydrate.jsx"),
-          "/foo.hydrate.js",
+          resolve("file:///proj/src/foo.client.jsx"),
+          "/foo.client.js",
           `srcDir=${JSON.stringify(srcDir)} の正規化が不正`,
         );
       }
@@ -69,61 +69,61 @@ describe("createHydrateModuleResolver", () => {
     it("URL エンコードされたパス (空白など) はエンコード形のまま維持する", () => {
       // browser の import() が specifier として直接使うため、literal space に
       // decode してはならない
-      const resolve = createHydrateModuleResolver();
+      const resolve = createClientModuleResolver();
       assert.strictEqual(
-        resolve("file:///proj/src/with%20space/foo.hydrate.jsx"),
-        "/with%20space/foo.hydrate.js",
+        resolve("file:///proj/src/with%20space/foo.client.jsx"),
+        "/with%20space/foo.client.js",
       );
     });
 
     it("経路の途中に src と紛らわしい名前 (src-review など) があっても最後の /src/ を採用する", () => {
-      const resolve = createHydrateModuleResolver();
+      const resolve = createClientModuleResolver();
       assert.strictEqual(
-        resolve("file:///Users/x/src-review/src/foo.hydrate.jsx"),
-        "/foo.hydrate.js",
+        resolve("file:///Users/x/src-review/src/foo.client.jsx"),
+        "/foo.client.js",
       );
     });
   });
 
   describe("エラー", () => {
     it("srcDir 配下にないモジュールは判別可能なエラーで失敗する", () => {
-      const resolve = createHydrateModuleResolver();
+      const resolve = createClientModuleResolver();
       assert.throws(
-        () => resolve("file:///proj/content/foo.hydrate.jsx"),
+        () => resolve("file:///proj/content/foo.client.jsx"),
         /must live under "src\/"/,
       );
     });
 
-    it(".hydrate.{js,jsx,ts,tsx} 以外はエラーで失敗する", () => {
-      const resolve = createHydrateModuleResolver();
+    it(".client.{js,jsx,ts,tsx} 以外はエラーで失敗する", () => {
+      const resolve = createClientModuleResolver();
       assert.throws(
         () => resolve("file:///proj/src/foo.jsx"),
-        /must end with \.hydrate/,
+        /must end with \.client/,
       );
     });
 
     it("URL として不正な値はエラーで失敗する", () => {
-      const resolve = createHydrateModuleResolver();
+      const resolve = createClientModuleResolver();
       assert.throws(() => resolve("not-a-url"), /Invalid module URL/);
     });
 
     it("srcDir が空文字列だと factory 呼び出しの時点で TypeError", () => {
       assert.throws(
-        () => createHydrateModuleResolver({ srcDir: "" }),
+        () => createClientModuleResolver({ srcDir: "" }),
         TypeError,
       );
     });
 
     it("srcDir が非文字列だと factory 呼び出しの時点で TypeError", () => {
       assert.throws(
-        () => createHydrateModuleResolver({ srcDir: 123 }),
+        () => createClientModuleResolver({ srcDir: 123 }),
         TypeError,
       );
     });
 
     it("urlPrefix が非文字列だと factory 呼び出しの時点で TypeError", () => {
       assert.throws(
-        () => createHydrateModuleResolver({ urlPrefix: 123 }),
+        () => createClientModuleResolver({ urlPrefix: 123 }),
         TypeError,
       );
     });

--- a/packages/eleventy-plugin-preact/README.md
+++ b/packages/eleventy-plugin-preact/README.md
@@ -72,12 +72,9 @@ export default function (eleventyConfig) {
   eleventyConfig.addPlugin(preact);
 
   // Partial hydration + client bundle + URL resolver (single source of truth).
-  // The URL prefix follows Eleventy's own `pathPrefix`, so it is not set here.
-  eleventyConfig.addPlugin(preactIsland, {
-    entries: "./src/**/*.client.jsx",
-    srcDir: "src",
-    outDir: "dist",
-  });
+  // Zero-config: it rides on Eleventy's input/output directories, the
+  // `.client.{js,jsx,ts,tsx}` convention, and Eleventy's own `pathPrefix`.
+  eleventyConfig.addPlugin(preactIsland);
 }
 ```
 

--- a/packages/eleventy-plugin-preact/README.md
+++ b/packages/eleventy-plugin-preact/README.md
@@ -71,12 +71,12 @@ export default function (eleventyConfig) {
   // Server-side rendering (no options)
   eleventyConfig.addPlugin(preact);
 
-  // Partial hydration + client bundle + URL resolver (single source of truth)
+  // Partial hydration + client bundle + URL resolver (single source of truth).
+  // The URL prefix follows Eleventy's own `pathPrefix`, so it is not set here.
   eleventyConfig.addPlugin(preactIsland, {
     entries: "./src/**/*.client.jsx",
     srcDir: "src",
     outDir: "dist",
-    urlPrefix: "/",
   });
 }
 ```

--- a/packages/eleventy-plugin-preact/README.md
+++ b/packages/eleventy-plugin-preact/README.md
@@ -25,49 +25,9 @@ export default function (eleventyConfig) {
 
 1. **Adds JSX/MDX template formats** - Use `.jsx` and `.mdx` files as Eleventy templates
 2. **Server-side rendering** - Renders Preact components to HTML using `preact-render-to-string`
-3. **Hydration bundles** - Optionally bundles `*.hydrate.jsx` files with esbuild for client-side hydration
+3. **Registers Node.js loaders** for JSX/MDX at module load time
 
-## Options
-
-### `hydrateGlob`
-
-- Type: `string`
-- Default: `undefined`
-
-Glob pattern for hydration entry points. Files matching this pattern will be:
-
-- Ignored by Eleventy (not processed as templates)
-- Bundled with esbuild for client-side use
-
-```javascript
-eleventyConfig.addPlugin(preact, {
-  hydrateGlob: "./src/**/*.hydrate.jsx",
-});
-```
-
-### `outbase`
-
-- Type: `string`
-- Default: `"src"`
-
-esbuild `outbase` used when bundling hydration entry points. Should match the directory prefix you want stripped from output paths (usually the Eleventy input directory).
-
-### `outdir`
-
-- Type: `string`
-- Default: `"dist"`
-
-esbuild `outdir` used when bundling hydration entry points. Usually the Eleventy output directory.
-
-```javascript
-eleventyConfig.addPlugin(preact, {
-  hydrateGlob: "./content/**/*.hydrate.jsx",
-  outbase: "content",
-  outdir: "_site",
-});
-```
-
-When you customize these, remember to also pass a matching `resolveHydrateUrl` to `@tuqulore-inc/eleventy-plugin-preact-island` so the browser URLs stay in sync.
+Client-side bundling and partial hydration are the responsibility of a companion package — see [With Partial Hydration](#with-partial-hydration) below.
 
 ## Eleventy Data Access
 
@@ -101,20 +61,23 @@ import { eleventy } from "@tuqulore-inc/eleventy-plugin-preact/eleventy";
 
 ## With Partial Hydration
 
-For partial hydration, use this plugin together with `@tuqulore-inc/eleventy-plugin-preact-island`:
+For partial hydration, use this plugin together with `@tuqulore-inc/eleventy-plugin-preact-island`. The Island plugin owns client-side bundling (`*.client.jsx`), the Eleventy ignore rule, and the SSR-to-browser URL resolver — this plugin only does SSR.
 
 ```javascript
 import preact from "@tuqulore-inc/eleventy-plugin-preact";
 import preactIsland from "@tuqulore-inc/eleventy-plugin-preact-island";
 
 export default function (eleventyConfig) {
-  // Server-side rendering
-  eleventyConfig.addPlugin(preact, {
-    hydrateGlob: "./src/**/*.hydrate.jsx",
-  });
+  // Server-side rendering (no options)
+  eleventyConfig.addPlugin(preact);
 
-  // Partial hydration
-  eleventyConfig.addPlugin(preactIsland);
+  // Partial hydration + client bundle + URL resolver (single source of truth)
+  eleventyConfig.addPlugin(preactIsland, {
+    entries: "./src/**/*.client.jsx",
+    srcDir: "src",
+    outDir: "dist",
+    urlPrefix: "/",
+  });
 }
 ```
 

--- a/packages/eleventy-plugin-preact/index.d.ts
+++ b/packages/eleventy-plugin-preact/index.d.ts
@@ -1,38 +1,16 @@
 import type { UserConfig } from "@11ty/eleventy";
 
-export interface PluginOptions {
-  /**
-   * Glob pattern for hydration entry points.
-   * Files matching this pattern will be bundled with esbuild and ignored by Eleventy.
-   * Example: "./src/**\/*.hydrate.jsx"
-   */
-  hydrateGlob?: string;
-  /**
-   * esbuild `outbase` used when bundling hydration entry points.
-   * Should match the directory prefix you want stripped from output paths
-   * (usually the Eleventy input directory).
-   * @default "src"
-   */
-  outbase?: string;
-  /**
-   * esbuild `outdir` used when bundling hydration entry points.
-   * @default "dist"
-   */
-  outdir?: string;
-}
-
 /**
- * Eleventy plugin for Preact server-side rendering with JSX/MDX support
+ * Eleventy plugin for Preact server-side rendering with JSX/MDX support.
  *
  * Features:
  * - Adds JSX and MDX as template formats
  * - Renders Preact components to HTML using preact-render-to-string
- * - Bundles hydration entry points with esbuild
  * - Automatically registers Node.js loaders for JSX/MDX
+ *
+ * Client-side bundling and partial hydration are handled by
+ * `@tuqulore-inc/eleventy-plugin-preact-island`.
  */
-declare function preactPlugin(
-  eleventyConfig: UserConfig,
-  pluginOptions?: PluginOptions,
-): void;
+declare function preactPlugin(eleventyConfig: UserConfig): void;
 
 export default preactPlugin;

--- a/packages/eleventy-plugin-preact/index.mjs
+++ b/packages/eleventy-plugin-preact/index.mjs
@@ -2,7 +2,6 @@ import module from "node:module";
 import url from "node:url";
 import render from "preact-render-to-string";
 import { jsx } from "preact/jsx-runtime";
-import * as esbuild from "esbuild";
 import { _runWithEleventyData } from "./eleventy.mjs";
 
 // Register Node.js loaders for JSX/MDX support
@@ -16,31 +15,23 @@ module.register(
 );
 
 /**
- * Eleventy plugin for Preact server-side rendering with JSX/MDX support
+ * Eleventy plugin for Preact server-side rendering with JSX/MDX support.
+ *
+ * SSR only: registers `.jsx` / `.mdx` template formats and renders Preact
+ * components to HTML using preact-render-to-string. Client-side bundling and
+ * partial hydration are handled by `@tuqulore-inc/eleventy-plugin-preact-island`.
+ *
  * @param {import("@11ty/eleventy").UserConfig} eleventyConfig
- * @param {Object} pluginOptions
- * @param {string} [pluginOptions.hydrateGlob] - Glob pattern for hydration entry points
- * @param {string} [pluginOptions.outbase="src"] - esbuild `outbase` for hydration bundles
- * @param {string} [pluginOptions.outdir="dist"] - esbuild `outdir` for hydration bundles
  */
-export default function (eleventyConfig, pluginOptions = {}) {
+export default function (eleventyConfig) {
   try {
     eleventyConfig.versionCheck(">=3.0");
   } catch (e) {
     console.log(`[eleventy-plugin-preact] WARN: ${e.message}`);
   }
 
-  const { hydrateGlob, outbase = "src", outdir = "dist" } = pluginOptions;
-
   // Add JSX and MDX as template formats
   eleventyConfig.addTemplateFormats(["jsx", "mdx"]);
-
-  // Ignore hydration entry points (they are bundled separately)
-  if (hydrateGlob) {
-    // Convert glob to ignore pattern (remove leading ./)
-    const ignorePattern = hydrateGlob.replace(/^\.\//, "");
-    eleventyConfig.ignores.add(ignorePattern);
-  }
 
   // Add extension handler for JSX and MDX
   eleventyConfig.addExtension(["jsx", "mdx"], {
@@ -54,30 +45,4 @@ export default function (eleventyConfig, pluginOptions = {}) {
       };
     },
   });
-
-  // Setup esbuild for hydration bundles
-  if (hydrateGlob) {
-    const transformJsx = async ({ runMode }) => {
-      /** @type {import("esbuild").BuildOptions} */
-      const options = {
-        bundle: true,
-        entryPoints: [hydrateGlob],
-        external: ["preact"],
-        format: "esm",
-        jsx: "automatic",
-        jsxImportSource: "preact",
-        outbase,
-        outdir,
-      };
-      const ctx = await esbuild.context(options);
-      if (runMode === "build") {
-        await esbuild.build(options);
-        await esbuild.stop();
-      } else {
-        ctx.watch();
-      }
-    };
-
-    eleventyConfig.on("eleventy.before", transformJsx);
-  }
 }

--- a/packages/eleventy-plugin-preact/package.json
+++ b/packages/eleventy-plugin-preact/package.json
@@ -51,7 +51,6 @@
     "@babel/core": "^8.0.1",
     "@babel/preset-react": "^8.0.1",
     "@mdx-js/node-loader": "^3.1.0",
-    "esbuild": "^0.28.0",
     "preact-render-to-string": "^6.5.13"
   },
   "devDependencies": {

--- a/packages/eleventy-preset/README.md
+++ b/packages/eleventy-preset/README.md
@@ -43,7 +43,7 @@ export default preset((eleventyConfig) => {
 | -------------------- | ------------------------------------------------- |
 | Input directory      | `src`                                             |
 | Output directory     | `dist`                                            |
-| Hydration glob       | `./src/**/*.hydrate.jsx`                          |
+| Client entries       | `./src/**/*.client.jsx`                           |
 | PostCSS content glob | `src/**/*.{md,mdx,jsx}`                           |
 | Server watches       | `dist/**/*.css`                                   |
 | Markdown             | `breaks: true`, `linkify: true`                   |
@@ -69,7 +69,7 @@ This preset supports JSX and MDX as template languages via `@tuqulore-inc/eleven
 
 ```mdx
 import { Island } from "@tuqulore-inc/eleventy-preset/island";
-import Clicker from "./clicker.hydrate.jsx";
+import Clicker from "./clicker.client.jsx";
 
 export const data = {
   layout: "post",
@@ -245,15 +245,15 @@ import Footer from "./partials/footer.mdx";
 
 ## Partial Hydration
 
-This preset supports partial hydration using `@tuqulore-inc/eleventy-plugin-preact-island`. Author hydration components under `src/**/*.hydrate.jsx`, mark the default export with `hydratable()`, and render them from any JSX/MDX template through the `<Island>` wrapper.
+This preset supports partial hydration using `@tuqulore-inc/eleventy-plugin-preact-island`. Author client components under `src/**/*.client.jsx`, mark the default export with `clientComponent()`, and render them from any JSX/MDX template through the `<Island>` wrapper.
 
-### Creating a Hydrated Component
+### Creating a Client Component
 
-Name your component with the `.hydrate.jsx` suffix and mark the default export with `hydratable`:
+Name your component with the `.client.jsx` suffix and mark the default export with `clientComponent`:
 
 ```jsx
-// src/clicker.hydrate.jsx
-import { hydratable } from "@tuqulore-inc/eleventy-preset/island";
+// src/clicker.client.jsx
+import { clientComponent } from "@tuqulore-inc/eleventy-preset/island";
 import { useState } from "preact/hooks";
 
 function Clicker() {
@@ -267,10 +267,10 @@ function Clicker() {
   );
 }
 
-export default hydratable(Clicker, import.meta.url);
+export default clientComponent(Clicker, import.meta.url);
 ```
 
-`hydratable(Component, import.meta.url)` attaches the SSR-side module URL as metadata; the preset's URL resolver converts it to the browser URL (`src/foo.hydrate.jsx` → `/foo.hydrate.js`).
+`clientComponent(Component, import.meta.url)` attaches the SSR-side module URL as metadata; the preset's URL resolver converts it to the browser URL (`src/foo.client.jsx` → `/foo.client.js`).
 
 ### Using in MDX
 
@@ -278,14 +278,14 @@ Import the component and wrap with `<Island>`. Extra props are forwarded to both
 
 ```mdx
 import { Island } from "@tuqulore-inc/eleventy-preset/island";
-import Clicker from "./clicker.hydrate.jsx";
+import Clicker from "./clicker.client.jsx";
 
 <Island component={Clicker} on="interaction" />
 ```
 
 ```mdx
 import { Island } from "@tuqulore-inc/eleventy-preset/island";
-import Navigation from "./partials/header/navigation.hydrate.jsx";
+import Navigation from "./partials/header/navigation.client.jsx";
 
 <Island
   component={Navigation}
@@ -307,7 +307,7 @@ The `on` prop maps to the `land-on:<value>` attribute on the underlying `<is-lan
 
 For parameterized triggers such as `on:media("(min-width: ...)")`, drop down to the raw `<is-land>` element (still supported); the injected setup script keeps working.
 
-See [@tuqulore-inc/eleventy-plugin-preact-island](../eleventy-plugin-preact-island/README.md) for the underlying plugin, including how to swap the URL resolver when using it outside this preset.
+See [@tuqulore-inc/eleventy-plugin-preact-island](../eleventy-plugin-preact-island/README.md) for the underlying plugin, including the `setClientModuleResolver` escape hatch for build layouts that don't fit the `.client.jsx` convention.
 
 ## Requirements
 

--- a/packages/eleventy-preset/README.md
+++ b/packages/eleventy-preset/README.md
@@ -43,7 +43,7 @@ export default preset((eleventyConfig) => {
 | -------------------- | ------------------------------------------------- |
 | Input directory      | `src`                                             |
 | Output directory     | `dist`                                            |
-| Client entries       | `./src/**/*.client.jsx`                           |
+| Client entries       | `src/**/*.client.{js,jsx,ts,tsx}`                 |
 | PostCSS content glob | `src/**/*.{md,mdx,jsx}`                           |
 | Server watches       | `dist/**/*.css`                                   |
 | Markdown             | `breaks: true`, `linkify: true`                   |
@@ -245,7 +245,7 @@ import Footer from "./partials/footer.mdx";
 
 ## Partial Hydration
 
-This preset supports partial hydration using `@tuqulore-inc/eleventy-plugin-preact-island`. Author client components under `src/**/*.client.jsx`, mark the default export with `clientComponent()`, and render them from any JSX/MDX template through the `<Island>` wrapper.
+This preset supports partial hydration using `@tuqulore-inc/eleventy-plugin-preact-island`. Author client components under `src/**/*.client.{js,jsx,ts,tsx}`, mark the default export with `clientComponent()`, and render them from any JSX/MDX template through the `<Island>` wrapper. No configuration is needed — the plugin picks them up by convention.
 
 ### Creating a Client Component
 
@@ -307,7 +307,7 @@ The `on` prop maps to the `land-on:<value>` attribute on the underlying `<is-lan
 
 For parameterized triggers such as `on:media("(min-width: ...)")`, drop down to the raw `<is-land>` element (still supported); the injected setup script keeps working.
 
-See [@tuqulore-inc/eleventy-plugin-preact-island](../eleventy-plugin-preact-island/README.md) for the underlying plugin, including the `setClientModuleResolver` escape hatch for build layouts that don't fit the `.client.jsx` convention.
+See [@tuqulore-inc/eleventy-plugin-preact-island](../eleventy-plugin-preact-island/README.md) for the underlying plugin, including the `bundle: false` option for bringing your own bundler.
 
 ## Requirements
 

--- a/packages/eleventy-preset/index.mjs
+++ b/packages/eleventy-preset/index.mjs
@@ -50,12 +50,10 @@ export default function preset(extend = () => {}) {
     // Preact SSR
     eleventyConfig.addPlugin(preact);
 
-    // Preact partial hydration with is-land (owns client bundle + URL resolver)
-    eleventyConfig.addPlugin(preactIsland, {
-      entries: `./${SRC_DIR}/**/*.client.jsx`,
-      srcDir: SRC_DIR,
-      outDir: OUT_DIR,
-    });
+    // Preact partial hydration with is-land. Zero-config: it reads Eleventy's
+    // input/output directories (set above) and the `.client.{js,jsx,ts,tsx}`
+    // convention, owning the client bundle + Eleventy ignore + URL resolver.
+    eleventyConfig.addPlugin(preactIsland);
 
     // PostCSS processing
     eleventyConfig.addPlugin(postcss, {

--- a/packages/eleventy-preset/index.mjs
+++ b/packages/eleventy-preset/index.mjs
@@ -5,10 +5,10 @@ import preactIsland from "@tuqulore-inc/eleventy-plugin-preact-island";
 import fg from "fast-glob";
 import path from "node:path";
 
-// This preset's directory / URL convention.
+// This preset's directory convention. The URL prefix follows Eleventy's own
+// `pathPrefix`, so it is not duplicated here.
 const SRC_DIR = "src";
 const OUT_DIR = "dist";
-const URL_PREFIX = "/";
 
 /**
  * Optimize images under SRC_DIR and output the same tree under OUT_DIR
@@ -55,7 +55,6 @@ export default function preset(extend = () => {}) {
       entries: `./${SRC_DIR}/**/*.client.jsx`,
       srcDir: SRC_DIR,
       outDir: OUT_DIR,
-      urlPrefix: URL_PREFIX,
     });
 
     // PostCSS processing

--- a/packages/eleventy-preset/index.mjs
+++ b/packages/eleventy-preset/index.mjs
@@ -2,12 +2,10 @@ import Image from "@11ty/eleventy-img";
 import postcss from "@tuqulore-inc/eleventy-plugin-postcss";
 import preact from "@tuqulore-inc/eleventy-plugin-preact";
 import preactIsland from "@tuqulore-inc/eleventy-plugin-preact-island";
-import { createHydrateModuleResolver } from "@tuqulore-inc/eleventy-plugin-preact-island/resolver";
 import fg from "fast-glob";
 import path from "node:path";
 
-// This preset's directory / URL convention. Both the SSR bundler and the Island
-// URL resolver are wired from these values so the two stay in sync.
+// This preset's directory / URL convention.
 const SRC_DIR = "src";
 const OUT_DIR = "dist";
 const URL_PREFIX = "/";
@@ -49,19 +47,15 @@ export default function preset(extend = () => {}) {
     eleventyConfig.setInputDirectory(SRC_DIR);
     eleventyConfig.setOutputDirectory(OUT_DIR);
 
-    // Preact SSR + hydration
-    eleventyConfig.addPlugin(preact, {
-      hydrateGlob: `./${SRC_DIR}/**/*.hydrate.jsx`,
-      outbase: SRC_DIR,
-      outdir: OUT_DIR,
-    });
+    // Preact SSR
+    eleventyConfig.addPlugin(preact);
 
-    // Preact partial hydration with is-land
+    // Preact partial hydration with is-land (owns client bundle + URL resolver)
     eleventyConfig.addPlugin(preactIsland, {
-      resolveHydrateUrl: createHydrateModuleResolver({
-        srcDir: SRC_DIR,
-        urlPrefix: URL_PREFIX,
-      }),
+      entries: `./${SRC_DIR}/**/*.client.jsx`,
+      srcDir: SRC_DIR,
+      outDir: OUT_DIR,
+      urlPrefix: URL_PREFIX,
     });
 
     // PostCSS processing

--- a/packages/eleventy-preset/island.d.ts
+++ b/packages/eleventy-preset/island.d.ts
@@ -1,6 +1,6 @@
 export {
   Island,
-  hydratable,
-  type HydratableComponent,
+  clientComponent,
+  type ClientComponent,
   type IslandProps,
 } from "@tuqulore-inc/eleventy-plugin-preact-island/island";

--- a/packages/eleventy-preset/island.mjs
+++ b/packages/eleventy-preset/island.mjs
@@ -1,4 +1,4 @@
 export {
   Island,
-  hydratable,
+  clientComponent,
 } from "@tuqulore-inc/eleventy-plugin-preact-island/island";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       esbuild:
         specifier: ^0.28.0
         version: 0.28.1
+      fast-glob:
+        specifier: ^3.3.3
+        version: 3.3.3
     devDependencies:
       '@tuqulore-inc/eslint-config':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,9 +69,6 @@ importers:
       '@mdx-js/node-loader':
         specifier: ^3.1.0
         version: 3.1.1
-      esbuild:
-        specifier: ^0.28.0
-        version: 0.28.1
       preact:
         specifier: '>=10.0.0'
         version: 10.29.4
@@ -94,6 +91,9 @@ importers:
       '@11ty/is-land':
         specifier: ^5.0.0
         version: 5.0.1
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.1
     devDependencies:
       '@tuqulore-inc/eslint-config':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

- **責務再整理**: `eleventy-plugin-preact` を純 SSR プラグインに縮小し、client bundle・Eleventy ignore・SSR-to-browser URL resolver の全てを `eleventy-plugin-preact-island` に集約。preset で 2 プラグイン間の整合を手作業で取っていた歪みを解消。
- **命名整理**: Islands アーキテクチャ語彙 (`client`) にファイル/関数/型/メタデータ全てを統一。前 API の実装用語 (`hydrate`) は概念語としての用法だけ残し、識別子からは排除。
- **API 縮退 (レビュー議論後の追加決定)**: オプションと拡張点を「`.client.*` 規約 + Eleventy 自身の設定への相乗り」に全面移行。プラグインオプションは `preactVersion` / `bundle` の 2 つのみ。入出力ディレクトリは `eleventyConfig.directories`、URL prefix は `pathPrefix` に追随し、`setClientModuleResolver` escape hatch と `./resolver` サブパスは削除。

## Motivation

前 PR #895 で見えていた 2 つの構造問題 (責務分裂・命名非対称) への対処に加え、レビュー議論で以下を確認・決定した:

1. **escape hatch (`setClientModuleResolver`) は文書通りに動かない**: Eleventy 3 は `addPlugin` をキューし config 関数 return 後に実行するため、「`addPlugin` の後に呼べ」という README の指示がテキスト上の順序と実行順序で逆転し、プラグインのデフォルト resolver がカスタム resolver を後から上書きする (実 Eleventy で確認)。グローバル可変状態の公開自体が順序不透明の根源であり、対象ユーザーも仮説のみ。規約に乗らないユーザーの逃げ道は raw `<is-land>` 直書きとして既に存在するため、公開 API から削除。
2. **`srcDir` / `outDir` の「Eleventy 設定と合わせろ」注意書きは `urlPrefix` と同種の二重配線**: Eleventy はプラグイン実行時に `eleventyConfig.directories` (userspace live getter、`setInputDirectory`/`setOutputDirectory` を反映) と `pathPrefix` を提供する (実 Eleventy で確認)。プラグイン独自の複製オプションは全て削除し、単一設定源へ。
3. **`entries` は規約から導出可能**: 自由 glob を残す理由は「規約から外れたい」以外になく、方針と矛盾。opt-out したいのは esbuild だけで、Eleventy ignore は規約の一部として常時有効にすべき (BYO バンドラーでも `.client.*` がページとしてレンダリングされてはならない) ため、`bundle: false` に分解。

## Breaking changes 一覧 (vs main)

### プラグインオプション

| 旧 | 新 |
|---|---|
| `hydrateGlob` (`eleventy-plugin-preact`) | 削除 — `<input>/**/*.client.{js,jsx,ts,tsx}` を自動発見 |
| `outbase` (`eleventy-plugin-preact`) | 削除 — `eleventyConfig.directories.input` に追随 |
| `outdir` (`eleventy-plugin-preact`) | 削除 — `eleventyConfig.directories.output` に追随 |
| `resolveHydrateUrl` (island) | 削除 — 規約非採用者は raw `<is-land>` 直書き |
| `urlPrefix` (island) | 削除 — Eleventy `pathPrefix` に追随 |
| — | `bundle: boolean = true` 新設 — `false` で esbuild のみ停止 (ignore・resolver・script 注入は常時有効) |

### ファイル/識別子

| 旧 | 新 |
|---|---|
| `*.hydrate.{js,jsx,ts,tsx}` | `*.client.{js,jsx,ts,tsx}` |
| `hydratable(Component, url)` | `clientComponent(Component, url)` |
| `__hydrateModuleUrl` (メタデータ) | `__clientModuleUrl` |
| `_setHydrateModuleResolver` (`@internal`) | `_setClientModuleResolver` (`@internal` のまま、公開せず) |
| `createHydrateModuleResolver` / `./resolver` サブパス | 内部化 (サブパス export 削除) |
| `HydratableComponent<P>` (型) | `ClientComponent<P>` |

### 変更しないもの

- JSX コンポーネント `<Island>` / 型 `IslandProps` / `clientComponent` / `./island` サブパス
- パッケージ名、`preactVersion` オプション
- raw `<is-land>` の完全サポート (script 注入は不変)

## Before / After (呼び出し側)

**Before** (main):

```js
// eleventy.config.mjs
eleventyConfig.addPlugin(preact, {
  hydrateGlob: "./src/**/*.hydrate.jsx",
  outbase: "src",
  outdir: "dist",
});
eleventyConfig.addPlugin(preactIsland, {
  resolveHydrateUrl: createHydrateModuleResolver({ srcDir: "src", urlPrefix: "/" }),
});
```

**After**:

```js
// eleventy.config.mjs
eleventyConfig.addPlugin(preact);
eleventyConfig.addPlugin(preactIsland); // ゼロコンフィグ
```

```jsx
// src/counter.client.jsx
import { clientComponent } from "@tuqulore-inc/eleventy-plugin-preact-island/island";
export default clientComponent(Counter, import.meta.url);
```

BYO バンドラー (esbuild を使わず自前で `.client.js` を規約レイアウトに出力する場合):

```js
eleventyConfig.addPlugin(preactIsland, { bundle: false });
```

## サブディレクトリデプロイ

Eleventy `pathPrefix` を宣言すれば、`<is-land import>` と importmap の `is-land` エントリの両方が追随する:

```js
export default function (eleventyConfig) {
  eleventyConfig.addPlugin(preactIsland);
  return { pathPrefix: "/my-site/" };
}
```

→ `<is-land import="/my-site/counter.client.js">` + `"is-land": "/my-site/is-land.js"`

importmap 側は本 PR での修正。従来は `/is-land.js` 固定だったため、サブディレクトリ配下では `import "is-land"` が 404 になり hydration 自体が壊れていた。

## その他の改善

- **resolver を絶対 input パス前方一致に書き換え**: 旧「`/src/` マーカー部分文字列検索」は Eleventy デフォルトの `input: "."` を表現できず、`node_modules/pkg/src/*.client.jsx` に偽マッチする穴があった。
- **esbuild エントリを fast-glob の明示リスト化**: esbuild ワイルドカードはブレース展開未対応。0 件時は esbuild をスキップし、Island を使わないサイトでもビルドが通る。`node_modules` は明示 ignore。
- **esbuild 呼び出しの整理** (前コミットから継承): build 時は `esbuild.build()` のみ、watch/serve は context を初回のみ生成。
- **テスト強化**: unit — pathPrefix×directories 追随・importmap 追随・bundle/ignore 分離・resolver 偽マッチ回帰 (island 40 pass)。E2E — `dist/**/*.client.js` 実在・`<is-land import>` URL・`.client.*` がページとして出力されないことの回帰検知。

## Test plan

- [x] `pnpm -r test` — island 40 / preact 19 / create-eleventy E2E 7 全 pass
- [x] `pnpm -r lint` / `pnpm format`
- [x] scaffold 実ビルドで `dist/**/*.client.js` 生成・ignore (`.client.*` のページ非生成)・importmap を確認
- [x] サブディレクトリデプロイ: `pathPrefix: "/sub/"` の実ビルドで `<is-land import="/sub/clicker.client.js">` と `"is-land": "/sub/is-land.js"` を確認
- [x] Eleventy 3 のプラグイン実行タイミング (directories / pathPrefix が config return 後にプラグインへ供給されること) を実 Eleventy 3.1.2 で検証
- [ ] scaffold して `pnpm dev` → ブラウザで Clicker / Desktop nav / Mobile nav が実際に client hydrate する動作を目視確認

## リリースについて

前 PR #895 は未リリース。この PR の破壊的変更は次回のメンテナ判断でメジャーリリースにまとめて包む前提。本 PR ではバージョン変更なし (`4.1.1-alpha.0` のまま)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
