### PR TITLE
fix(create-eleventy): default template のアクセシビリティとセマンティクスを底上げする

### DIFF
--- a/packages/create-eleventy/templates/default/Dockerfile
+++ b/packages/create-eleventy/templates/default/Dockerfile
@@ -5,14 +5,13 @@ RUN corepack enable
 RUN pnpm install --frozen-lockfile
 COPY postcss.config.js eleventy.config.js .env* ./
 COPY src/ ./src
-COPY lib/ ./lib
 RUN pnpm build
 
 FROM node:24-slim@sha256:cb4e8f7c443347358b7875e717c29e27bf9befc8f5a26cf18af3c3dec80e58c5 as install
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 RUN corepack enable
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --prod
 
 FROM gcr.io/distroless/nodejs24-debian13@sha256:ac0daf5d207757b275f3df0de9b296675500e773cc447c65afd66a948d5bf013
 WORKDIR /app

--- a/packages/create-eleventy/templates/default/eslint.config.js
+++ b/packages/create-eleventy/templates/default/eslint.config.js
@@ -23,7 +23,7 @@ export default defineConfig([
     files: ["**/*.cjs", "*.js", "src/_data/**/*.js"],
     languageOptions: { globals: globals.node },
   },
-  react.configs.flat.recommended,
+  { ...react.configs.flat.recommended, files: ["**/*.{jsx,mdx}"] },
   {
     files: ["**/*.{jsx,mdx}"],
     plugins: { react },
@@ -35,6 +35,13 @@ export default defineConfig([
         ...globals.serviceworker,
         ...globals.browser,
       },
+    },
+    settings: {
+      // NOTE: 本テンプレートは Preact 処理系だが、eslint-plugin-react の
+      // JSX 構文ルール (jsx-key など) を流用したい。version 未指定だと
+      // "React version not specified" 警告が出るので、Preact 10 の JSX
+      // runtime が API 互換な React 18 系をスタブとして与えて抑制する。
+      react: { version: "18.3.0" },
     },
     rules: {
       "react/jsx-uses-react": "off",

--- a/packages/create-eleventy/templates/default/src/__data/nav.json
+++ b/packages/create-eleventy/templates/default/src/__data/nav.json
@@ -1,15 +1,12 @@
 [
   {
-    "name": "Group Menu",
+    "name": "Group A",
     "children": [
-      { "name": "Menu", "path": "/" },
-      { "name": "Menu", "path": "/" },
-      { "name": "Menu", "path": "/" },
-      { "name": "Menu", "path": "/" },
-      { "name": "Menu", "path": "/" },
-      { "name": "Menu", "path": "/" }
+      { "name": "Item A-1", "path": "/" },
+      { "name": "Item A-2", "path": "/" },
+      { "name": "Item A-3", "path": "/" }
     ]
   },
-  { "name": "Menu", "path": "/" },
-  { "name": "Menu", "path": "/" }
+  { "name": "Item B", "path": "/" },
+  { "name": "Item C", "path": "/" }
 ]

--- a/packages/create-eleventy/templates/default/src/__data/site.js
+++ b/packages/create-eleventy/templates/default/src/__data/site.js
@@ -1,3 +1,9 @@
+if (!process.env.SITE_URL) {
+  throw new Error(
+    "SITE_URL is not set. Define it in .env (or the appropriate .env.{development,production}[.local]) so canonical/OGP URLs can be built.",
+  );
+}
+
 export default {
   description: "Site Description",
   name: "Site Name",

--- a/packages/create-eleventy/templates/default/src/__includes/base.mdx
+++ b/packages/create-eleventy/templates/default/src/__includes/base.mdx
@@ -15,11 +15,18 @@ import Footer from "./partials/footer.mdx";
     </title>
   </head>
   <body>
+    <a
+      href="#main"
+      class="jumpu-button sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50"
+    >
+      本文へスキップ
+    </a>
     <Header />
-    <div
+    <main
+      id="main"
       class="mx-auto mb-4 min-h-[60vh] max-w-6xl px-4"
       dangerouslySetInnerHTML={{ __html: eleventy.content }}
-    ></div>
+    ></main>
     <Footer />
   </body>
 </html>

--- a/packages/create-eleventy/templates/default/src/__includes/base.mdx
+++ b/packages/create-eleventy/templates/default/src/__includes/base.mdx
@@ -7,12 +7,12 @@ import Footer from "./partials/footer.mdx";
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <Ogp />
-    <link rel="stylesheet" href="/main.css" />
     <title>
       {eleventy.title && `${eleventy.title} | `}
       {eleventy.site.name}
     </title>
+    <Ogp />
+    <link rel="stylesheet" href="/main.css" />
   </head>
   <body>
     <a

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
@@ -29,7 +29,14 @@ function MenuList(props) {
     };
   }, []);
   return (
-    <div role="presentation" ref={ref}>
+    <div
+      role="presentation"
+      ref={ref}
+      onFocusOut={(e) => {
+        if (ref.current?.contains(e.relatedTarget)) return;
+        setOpen(false);
+      }}
+    >
       <button
         id={`nav-button-${slugify(props.item.name)}`}
         ref={buttonRef}

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
@@ -12,8 +12,9 @@ function MenuList(props) {
   const buttonRef = useRef(null);
   const slug = `${slugify(props.item.name)}-${props.index}`;
   useEffect(() => {
+    if (!open) return;
     const clickHandler = (e) => {
-      if (!ref.current || ref.current.contains(e.target)) return;
+      if (ref.current?.contains(e.target)) return;
       setOpen(false);
     };
     const keyHandler = (e) => {
@@ -28,7 +29,7 @@ function MenuList(props) {
       document.removeEventListener("click", clickHandler);
       document.removeEventListener("keydown", keyHandler);
     };
-  }, []);
+  }, [open]);
   return (
     <div
       ref={ref}

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
@@ -16,13 +16,14 @@ function MenuList(props) {
     };
     document.addEventListener("click", handler);
     return () => document.removeEventListener("click", handler);
-  }, [ref.current, setOpen]);
+  }, []);
   return (
     <div role="presentation" ref={ref}>
       <button
         id={`nav-button-${slugify(props.item.name)}`}
         aria-haspopup="menu"
         aria-controls={`nav-menu-${slugify(props.item.name)}`}
+        aria-expanded={open}
         class="jumpu-text-button"
         type="button"
         onClick={() => setOpen(!open)}

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
@@ -10,6 +10,7 @@ function MenuList(props) {
   const handleTransitionEnd = () => !open && setVisible(false);
   const ref = useRef(null);
   const buttonRef = useRef(null);
+  const slug = `${slugify(props.item.name)}-${props.index}`;
   useEffect(() => {
     const clickHandler = (e) => {
       if (!ref.current || ref.current.contains(e.target)) return;
@@ -30,7 +31,6 @@ function MenuList(props) {
   }, []);
   return (
     <div
-      role="presentation"
       ref={ref}
       onFocusOut={(e) => {
         if (ref.current?.contains(e.relatedTarget)) return;
@@ -38,9 +38,9 @@ function MenuList(props) {
       }}
     >
       <button
-        id={`nav-button-${slugify(props.item.name)}`}
+        id={`nav-button-${slug}`}
         ref={buttonRef}
-        aria-controls={`nav-menu-${slugify(props.item.name)}`}
+        aria-controls={`nav-menu-${slug}`}
         aria-expanded={open}
         class="jumpu-text-button"
         type="button"
@@ -49,8 +49,8 @@ function MenuList(props) {
         {props.item.name}
       </button>
       <ul
-        id={`nav-menu-${slugify(props.item.name)}`}
-        aria-labelledby={`nav-button-${slugify(props.item.name)}`}
+        id={`nav-menu-${slug}`}
+        aria-labelledby={`nav-button-${slug}`}
         class={twMerge(
           "jumpu-card absolute top-full left-1/2 max-h-[50vh] -translate-x-1/2 overflow-y-auto p-2",
           "translate-y-2 transition duration-75 ease-in-out",
@@ -73,7 +73,7 @@ function Desktop(props) {
         {props.nav.map((item, itemIndex) =>
           "children" in item ? (
             <li key={`${item.name}-${itemIndex}`} class="relative">
-              <MenuList item={item}>
+              <MenuList item={item} index={itemIndex}>
                 {item.children.map((child, childIndex) => (
                   <li key={`${child.name}-${childIndex}`}>
                     <a

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
@@ -9,18 +9,30 @@ function MenuList(props) {
   const handleTransitionStart = () => open && setVisible(true);
   const handleTransitionEnd = () => !open && setVisible(false);
   const ref = useRef(null);
+  const buttonRef = useRef(null);
   useEffect(() => {
-    const handler = (e) => {
+    const clickHandler = (e) => {
       if (!ref.current || ref.current.contains(e.target)) return;
       setOpen(false);
     };
-    document.addEventListener("click", handler);
-    return () => document.removeEventListener("click", handler);
+    const keyHandler = (e) => {
+      if (e.key !== "Escape") return;
+      if (!ref.current?.contains(e.target)) return;
+      setOpen(false);
+      buttonRef.current?.focus();
+    };
+    document.addEventListener("click", clickHandler);
+    document.addEventListener("keydown", keyHandler);
+    return () => {
+      document.removeEventListener("click", clickHandler);
+      document.removeEventListener("keydown", keyHandler);
+    };
   }, []);
   return (
     <div role="presentation" ref={ref}>
       <button
         id={`nav-button-${slugify(props.item.name)}`}
+        ref={buttonRef}
         aria-controls={`nav-menu-${slugify(props.item.name)}`}
         aria-expanded={open}
         class="jumpu-text-button"

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
@@ -21,7 +21,6 @@ function MenuList(props) {
     <div role="presentation" ref={ref}>
       <button
         id={`nav-button-${slugify(props.item.name)}`}
-        aria-haspopup="menu"
         aria-controls={`nav-menu-${slugify(props.item.name)}`}
         aria-expanded={open}
         class="jumpu-text-button"
@@ -32,7 +31,6 @@ function MenuList(props) {
       </button>
       <ul
         id={`nav-menu-${slugify(props.item.name)}`}
-        role="menu"
         aria-labelledby={`nav-button-${slugify(props.item.name)}`}
         class={twMerge(
           "jumpu-card absolute top-full left-1/2 max-h-[50vh] -translate-x-1/2 overflow-y-auto p-2",
@@ -58,7 +56,7 @@ function Desktop(props) {
             <li key={`${item.name}-${itemIndex}`} class="relative">
               <MenuList item={item}>
                 {item.children.map((child, childIndex) => (
-                  <li key={`${child.name}-${childIndex}`} role="menuitem">
+                  <li key={`${child.name}-${childIndex}`}>
                     <a
                       class="jumpu-text-button w-full whitespace-nowrap"
                       href={child.path}

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
@@ -5,8 +5,10 @@ import { twMerge } from "tailwind-merge";
 function Mobile(props) {
   const [open, setOpen] = useState(false);
   const openButtonRef = useRef(null);
+  const closeButtonRef = useRef(null);
   useEffect(() => {
     if (!open) return;
+    closeButtonRef.current?.focus();
     const handler = (e) => {
       if (e.key !== "Escape") return;
       setOpen(false);
@@ -26,7 +28,7 @@ function Mobile(props) {
         aria-label="Menu"
         class="jumpu-icon-button group h-12 w-12 text-2xl"
         type="button"
-        onClick={() => setOpen(true)}
+        onClick={() => setOpen((v) => !v)}
       >
         <span class="icon-[material-symbols--menu]"></span>
         <span
@@ -37,8 +39,11 @@ function Mobile(props) {
           Menu
         </span>
       </button>
-      <nav
+      <div
         id="nav-menu-mobile"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Global navigation"
         inert={!open}
         class={twMerge(
           "fixed top-0 left-0 h-screen w-screen overflow-y-auto bg-white",
@@ -47,11 +52,15 @@ function Mobile(props) {
         )}
       >
         <button
+          ref={closeButtonRef}
           class="jumpu-icon-button group fixed top-2 right-4 h-12 w-12 text-2xl"
           aria-describedby="nav-tooltip-close"
           aria-label="Close"
           type="button"
-          onClick={() => setOpen(false)}
+          onClick={() => {
+            setOpen(false);
+            openButtonRef.current?.focus();
+          }}
         >
           <span class="icon-[material-symbols--close]"></span>
           <span
@@ -62,32 +71,34 @@ function Mobile(props) {
             Close
           </span>
         </button>
-        <ul class="flex flex-col px-4 py-16">
-          {props.nav.map((item, itemIndex) => (
-            <li key={`${item.name}-${itemIndex}`}>
-              {item.children && (
-                <section class="mb-6">
-                  <h2 class="mb-2 ml-4 text-lg">{item.name}</h2>
-                  <ul>
-                    {item.children.map((child, childIndex) => (
-                      <li key={`${child.name}-${childIndex}`}>
-                        <a class="jumpu-text-button block" href={child.path}>
-                          {child.name}
-                        </a>
-                      </li>
-                    ))}
-                  </ul>
-                </section>
-              )}
-              {item.path && (
-                <a class="jumpu-text-button block" href={item.path}>
-                  {item.name}
-                </a>
-              )}
-            </li>
-          ))}
-        </ul>
-      </nav>
+        <nav>
+          <ul class="flex flex-col px-4 py-16">
+            {props.nav.map((item, itemIndex) => (
+              <li key={`${item.name}-${itemIndex}`}>
+                {item.children && (
+                  <section class="mb-6">
+                    <h2 class="mb-2 ml-4 text-lg">{item.name}</h2>
+                    <ul>
+                      {item.children.map((child, childIndex) => (
+                        <li key={`${child.name}-${childIndex}`}>
+                          <a class="jumpu-text-button block" href={child.path}>
+                            {child.name}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                )}
+                {item.path && (
+                  <a class="jumpu-text-button block" href={item.path}>
+                    {item.name}
+                  </a>
+                )}
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </div>
     </div>
   );
 }

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
@@ -60,8 +60,10 @@ function Mobile(props) {
             {props.nav.map((item, itemIndex) => (
               <li key={`${item.name}-${itemIndex}`}>
                 {item.children && (
-                  <section class="mb-6">
-                    <h2 class="mb-2 ml-4 text-lg">{item.name}</h2>
+                  <div class="mb-6" role="group" aria-label={item.name}>
+                    <p class="mb-2 ml-4 text-lg" aria-hidden="true">
+                      {item.name}
+                    </p>
                     <ul>
                       {item.children.map((child, childIndex) => (
                         <li key={`${child.name}-${childIndex}`}>
@@ -71,7 +73,7 @@ function Mobile(props) {
                         </li>
                       ))}
                     </ul>
-                  </section>
+                  </div>
                 )}
                 {item.path && (
                   <a class="jumpu-text-button block" href={item.path}>

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
@@ -9,13 +9,19 @@ function Mobile(props) {
   useEffect(() => {
     if (!open) return;
     closeButtonRef.current?.focus();
+    // NOTE: メニュー表示中は背景 (html) のスクロールを止め、モバイルで
+    // メニューをスクロールしたつもりが背後のページも動く事故を防ぐ。
+    document.documentElement.classList.add("overflow-hidden");
     const handler = (e) => {
       if (e.key !== "Escape") return;
       setOpen(false);
       openButtonRef.current?.focus();
     };
     document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
+    return () => {
+      document.removeEventListener("keydown", handler);
+      document.documentElement.classList.remove("overflow-hidden");
+    };
   }, [open]);
   return (
     <div class={props.class}>
@@ -36,7 +42,7 @@ function Mobile(props) {
         aria-label="Global navigation"
         inert={!open}
         class={twMerge(
-          "fixed top-0 left-0 h-screen w-screen overflow-y-auto bg-white",
+          "fixed top-0 left-0 h-screen w-screen overflow-y-auto overscroll-contain bg-white",
           "transition duration-150 ease-in-out",
           open ? "translate-x-0" : "translate-x-full",
         )}

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
@@ -1,13 +1,25 @@
 import { clientComponent } from "@tuqulore-inc/eleventy-preset/island";
-import { useState } from "preact/hooks";
+import { useEffect, useRef, useState } from "preact/hooks";
 import { twMerge } from "tailwind-merge";
 
 function Mobile(props) {
   const [open, setOpen] = useState(false);
+  const openButtonRef = useRef(null);
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e) => {
+      if (e.key !== "Escape") return;
+      setOpen(false);
+      openButtonRef.current?.focus();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open]);
   return (
     <div class={props.class}>
       <button
         id="nav-button-mobile"
+        ref={openButtonRef}
         aria-controls="nav-menu-mobile"
         aria-describedby="nav-tooltip-mobile"
         aria-expanded={open}

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
@@ -27,6 +27,7 @@ function Mobile(props) {
       </button>
       <nav
         id="nav-menu-mobile"
+        inert={!open}
         class={twMerge(
           "fixed top-0 left-0 h-screen w-screen overflow-y-auto bg-white",
           "transition duration-150 ease-in-out",
@@ -35,9 +36,7 @@ function Mobile(props) {
       >
         <button
           class="jumpu-icon-button group fixed top-2 right-4 h-12 w-12 text-2xl"
-          aria-controls="nav-menu-mobile"
           aria-describedby="nav-tooltip-close"
-          aria-expanded={open}
           aria-label="Close"
           type="button"
           onClick={() => setOpen(false)}

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
@@ -23,21 +23,13 @@ function Mobile(props) {
         id="nav-button-mobile"
         ref={openButtonRef}
         aria-controls="nav-menu-mobile"
-        aria-describedby="nav-tooltip-mobile"
         aria-expanded={open}
-        aria-label="Menu"
-        class="jumpu-icon-button group h-12 w-12 text-2xl"
+        aria-label="Open navigation menu"
+        class="jumpu-icon-button h-12 w-12 text-2xl"
         type="button"
         onClick={() => setOpen((v) => !v)}
       >
         <span class="icon-[material-symbols--menu]"></span>
-        <span
-          id="nav-tooltip-mobile"
-          role="tooltip"
-          class="![transform:translate(-50%,_225%)_scale(0)] group-hover:![transform:translate(-50%,_225%)_scale(1)]"
-        >
-          Menu
-        </span>
       </button>
       <div
         id="nav-menu-mobile"
@@ -53,9 +45,8 @@ function Mobile(props) {
       >
         <button
           ref={closeButtonRef}
-          class="jumpu-icon-button group fixed top-2 right-4 h-12 w-12 text-2xl"
-          aria-describedby="nav-tooltip-close"
-          aria-label="Close"
+          class="jumpu-icon-button fixed top-2 right-4 h-12 w-12 text-2xl"
+          aria-label="Close navigation menu"
           type="button"
           onClick={() => {
             setOpen(false);
@@ -63,13 +54,6 @@ function Mobile(props) {
           }}
         >
           <span class="icon-[material-symbols--close]"></span>
-          <span
-            id="nav-tooltip-close"
-            role="tooltip"
-            class="![transform:translate(-50%,_225%)_scale(0)] group-hover:![transform:translate(-50%,_225%)_scale(1)]"
-          >
-            Close
-          </span>
         </button>
         <nav>
           <ul class="flex flex-col px-4 py-16">

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
@@ -10,6 +10,8 @@ function Mobile(props) {
         id="nav-button-mobile"
         aria-controls="nav-menu-mobile"
         aria-describedby="nav-tooltip-mobile"
+        aria-expanded={open}
+        aria-label="Menu"
         class="jumpu-icon-button group h-12 w-12 text-2xl"
         type="button"
         onClick={() => setOpen(true)}
@@ -33,7 +35,10 @@ function Mobile(props) {
       >
         <button
           class="jumpu-icon-button group fixed top-2 right-4 h-12 w-12 text-2xl"
+          aria-controls="nav-menu-mobile"
           aria-describedby="nav-tooltip-close"
+          aria-expanded={open}
+          aria-label="Close"
           type="button"
           onClick={() => setOpen(false)}
         >

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
@@ -24,9 +24,7 @@ function Mobile(props) {
         ref={openButtonRef}
         aria-controls="nav-menu-mobile"
         aria-expanded={open}
-        aria-label={
-          open ? "Close navigation menu" : "Open navigation menu"
-        }
+        aria-label={open ? "Close navigation menu" : "Open navigation menu"}
         class="jumpu-icon-button h-12 w-12 text-2xl"
         type="button"
         onClick={() => setOpen((v) => !v)}

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
@@ -24,17 +24,17 @@ function Mobile(props) {
         ref={openButtonRef}
         aria-controls="nav-menu-mobile"
         aria-expanded={open}
-        aria-label="Open navigation menu"
+        aria-label={
+          open ? "Close navigation menu" : "Open navigation menu"
+        }
         class="jumpu-icon-button h-12 w-12 text-2xl"
         type="button"
         onClick={() => setOpen((v) => !v)}
       >
         <span class="icon-[material-symbols--menu]"></span>
       </button>
-      <div
+      <nav
         id="nav-menu-mobile"
-        role="dialog"
-        aria-modal="true"
         aria-label="Global navigation"
         inert={!open}
         class={twMerge(
@@ -55,36 +55,34 @@ function Mobile(props) {
         >
           <span class="icon-[material-symbols--close]"></span>
         </button>
-        <nav>
-          <ul class="flex flex-col px-4 py-16">
-            {props.nav.map((item, itemIndex) => (
-              <li key={`${item.name}-${itemIndex}`}>
-                {item.children && (
-                  <div class="mb-6" role="group" aria-label={item.name}>
-                    <p class="mb-2 ml-4 text-lg" aria-hidden="true">
-                      {item.name}
-                    </p>
-                    <ul>
-                      {item.children.map((child, childIndex) => (
-                        <li key={`${child.name}-${childIndex}`}>
-                          <a class="jumpu-text-button block" href={child.path}>
-                            {child.name}
-                          </a>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-                {item.path && (
-                  <a class="jumpu-text-button block" href={item.path}>
+        <ul class="flex flex-col px-4 py-16">
+          {props.nav.map((item, itemIndex) => (
+            <li key={`${item.name}-${itemIndex}`}>
+              {item.children && (
+                <div class="mb-6" role="group" aria-label={item.name}>
+                  <p class="mb-2 ml-4 text-lg" aria-hidden="true">
                     {item.name}
-                  </a>
-                )}
-              </li>
-            ))}
-          </ul>
-        </nav>
-      </div>
+                  </p>
+                  <ul>
+                    {item.children.map((child, childIndex) => (
+                      <li key={`${child.name}-${childIndex}`}>
+                        <a class="jumpu-text-button block" href={child.path}>
+                          {child.name}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {item.path && (
+                <a class="jumpu-text-button block" href={item.path}>
+                  {item.name}
+                </a>
+              )}
+            </li>
+          ))}
+        </ul>
+      </nav>
     </div>
   );
 }

--- a/packages/create-eleventy/templates/default/src/__includes/partials/ogp.mdx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/ogp.mdx
@@ -19,4 +19,5 @@ import { eleventy } from "@tuqulore-inc/eleventy-preset/eleventy";
   property="og:image"
   content={new URL(eleventy.ogp ?? "/ogp.png", eleventy.site.url).href}
 />
+<meta property="og:image:alt" content={eleventy.title ?? eleventy.site.name} />
 <meta name="twitter:card" content="summary" />

--- a/packages/create-eleventy/templates/default/src/__includes/partials/ogp.mdx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/ogp.mdx
@@ -1,6 +1,10 @@
 import { eleventy } from "@tuqulore-inc/eleventy-preset/eleventy";
 
 <meta
+  name="description"
+  content={eleventy.description ?? eleventy.site.description}
+/>
+<meta
   property="og:description"
   content={eleventy.description ?? eleventy.site.description}
 />
@@ -15,4 +19,4 @@ import { eleventy } from "@tuqulore-inc/eleventy-preset/eleventy";
   property="og:image"
   content={new URL(eleventy.ogp ?? "/ogp.png", eleventy.site.url).href}
 />
-<meta property="twitter:card" content="summary" />
+<meta name="twitter:card" content="summary" />

--- a/packages/create-eleventy/templates/default/src/__includes/partials/ogp.mdx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/ogp.mdx
@@ -9,10 +9,10 @@ import { eleventy } from "@tuqulore-inc/eleventy-preset/eleventy";
 <meta property="og:type" content="website" />
 <meta
   property="og:url"
-  content={new URL(eleventy.site.url).origin.concat(eleventy.page.url)}
+  content={new URL(eleventy.page.url, eleventy.site.url).href}
 />
 <meta
   property="og:image"
-  content={new URL(eleventy.site.url).origin.concat(eleventy.ogp ?? "ogp.png")}
+  content={new URL(eleventy.ogp ?? "/ogp.png", eleventy.site.url).href}
 />
 <meta property="twitter:card" content="summary" />

--- a/packages/create-eleventy/templates/default/src/clicker.client.jsx
+++ b/packages/create-eleventy/templates/default/src/clicker.client.jsx
@@ -6,7 +6,11 @@ function Clicker() {
 
   return (
     <div>
-      <button class="jumpu-button" onClick={() => setCounter(counter + 1)}>
+      <button
+        type="button"
+        class="jumpu-button"
+        onClick={() => setCounter(counter + 1)}
+      >
         Count
       </button>
       <output>{counter}</output>

--- a/packages/create-eleventy/templates/default/src/clicker.client.jsx
+++ b/packages/create-eleventy/templates/default/src/clicker.client.jsx
@@ -5,7 +5,7 @@ function Clicker() {
   const [counter, setCounter] = useState(0);
 
   return (
-    <div>
+    <div class="flex items-center gap-4">
       <button
         type="button"
         class="jumpu-button"
@@ -13,7 +13,7 @@ function Clicker() {
       >
         Count
       </button>
-      <output>{counter}</output>
+      <output class="text-xl tabular-nums">{counter}</output>
     </div>
   );
 }

--- a/packages/create-eleventy/templates/default/src/clicker.client.jsx
+++ b/packages/create-eleventy/templates/default/src/clicker.client.jsx
@@ -9,7 +9,7 @@ function Clicker() {
       <button class="jumpu-button" onClick={() => setCounter(counter + 1)}>
         Count
       </button>
-      <p>{counter}</p>
+      <output>{counter}</output>
     </div>
   );
 }

--- a/packages/create-eleventy/templates/default/src/index.mdx
+++ b/packages/create-eleventy/templates/default/src/index.mdx
@@ -3,17 +3,22 @@ import Clicker from "./clicker.client.jsx";
 
 export const data = {
   layout: "post",
-  title: "Hello World",
+  title: "ようこそ",
 };
 
-# Hello World
+# ようこそ
 
-## Hello World
+これは default テンプレートのスターターページです。`src/index.mdx` を編集して、実際のコンテンツに置き換えてください。
 
-### Hello World
+## 含まれているもの
 
-#### Hello World
+- Eleventy + Preact + Tailwind CSS
+- MDX で書けるレイアウト・ページ
+- `.client.jsx` 命名によるパーシャルハイドレーション
+- Tailwind Typography による Markdown スタイル
 
-Hello World
+## Partial Hydration サンプル
+
+以下のカウンターは Preact コンポーネントで、初回操作時にクライアント側でハイドレーションされます。
 
 <Island component={Clicker} on="interaction" />

--- a/packages/create-eleventy/templates/default/src/main.css
+++ b/packages/create-eleventy/templates/default/src/main.css
@@ -2,3 +2,14 @@
 @import "@jumpu-ui/tailwindcss";
 @plugin "@tailwindcss/typography";
 @plugin "@iconify/tailwind4";
+
+@layer base {
+  html {
+    scroll-padding-top: 4rem;
+  }
+
+  :focus-visible {
+    outline: 2px solid AccentColor;
+    outline-offset: 2px;
+  }
+}

--- a/packages/eleventy-plugin-preact/index.js
+++ b/packages/eleventy-plugin-preact/index.js
@@ -40,7 +40,11 @@ export default function (eleventyConfig) {
       return async function (data) {
         return _runWithEleventyData(data, async () => {
           const content = await this.defaultRenderer(data);
-          return render(jsx(content.type, content.props, content.key));
+          const html = render(jsx(content.type, content.props, content.key));
+          // NOTE: preact-render-to-string does not emit a DOCTYPE, so full-page
+          // outputs land in quirks mode. Prepend only when the render actually
+          // starts with <html> to leave partial / island renders untouched.
+          return html.startsWith("<html") ? `<!doctype html>${html}` : html;
         });
       };
     },

--- a/packages/eleventy-plugin-preact/index.js
+++ b/packages/eleventy-plugin-preact/index.js
@@ -40,10 +40,14 @@ export default function (eleventyConfig) {
       return async function (data) {
         return _runWithEleventyData(data, async () => {
           const content = await this.defaultRenderer(data);
-          const html = render(jsx(content.type, content.props, content.key));
+          const html = render(
+            jsx(content.type, content.props, content.key),
+          ).trimStart();
           // NOTE: preact-render-to-string does not emit a DOCTYPE, so full-page
           // outputs land in quirks mode. Prepend only when the render actually
           // starts with <html> to leave partial / island renders untouched.
+          // trimStart しているのは MDX/JSX の出力先頭に改行や BOM 等の空白が
+          // 混ざり得るためで、その影響で startsWith 判定が外れないようにする。
           return html.startsWith("<html") ? `<!doctype html>${html}` : html;
         });
       };


### PR DESCRIPTION
## 主な変更点

### プラグイン

- `eleventy-plugin-preact`: full-page render に `<!doctype html>` を条件付きで付与 (partial / island 出力には影響しない)。quirks mode を解消する。

### `create-eleventy` の default template

**アクセシビリティ (ARIA / WCAG 2.2)**

- モバイルメニューはオフキャンバスナビゲーションとして実装し、閉状態は `inert` で Tab から遮断 (途中で `role="dialog" aria-modal="true"` 化を試みたが focus trap / 背景 inert 化のコストが雛形として過剰と判断してオフキャンバスに戻した)
- モバイルメニュー表示中は `<html>` に `overflow-hidden` を付け、`<nav>` にも `overscroll-contain` を追加して背景スクロールとスクロール連鎖を止める
- 開閉時の focus 遷移 (open ボタン ↔ close ボタン) と Escape キーでのクローズを両方のメニューに実装
- デスクトップメニューを APG Menu Button から Disclosure Navigation に降格 (`role="menu" / menuitem / aria-haspopup="menu"` を撤去) し、`focusout` でメニュー外に焦点が抜けたら自動クローズ
- デスクトップ MenuList の document リスナーは open 中だけ張るように変更 (常時登録 → open 依存)
- `<main id="main">` ランドマークと skip link を追加
- open ボタンの状態と `aria-expanded` の整合 (トグル化 + `aria-label` を open 状態に追従)
- モバイルナビの `<h2>` を `<div role="group" aria-label>` に置換 (SSR で常時 DOM に残り本文の h1 より前に出現していた)
- Clicker のカウンター表示を `<output>` に (implicit `aria-live="polite"`)
- `:focus-visible` スタイル (AccentColor) と sticky ヘッダ用 `scroll-padding-top` を `main.css` に追加
- モバイル open/close ボタンの `role="tooltip"` 実装を撤去 (キーボードで表示されず accname 混入リスクもあった)

**セマンティクス / OGP / URL 組み立て**

- `origin.concat()` を `new URL(path, base).href` に置き換え、`og:image` デフォルトを `/ogp.png` にしてスラッシュ欠落によるURL破損を修正
- `<meta name="description">` を追加、`<meta property="twitter:card">` を `name=` に修正
- `og:image:alt` を `eleventy.title ?? eleventy.site.name` で追加
- `<title>` を `<head>` の先頭 (`<link rel="stylesheet">` より前) に移動
- `SITE_URL` 未設定時に .env の設定先を含む Error を投げる (`site.js`)
- Dockerfile: 存在しない `lib/` の COPY を削除、install ステージに `--prod` を付ける

**サンプルデータ / スターター体験**

- `nav.json` の "Menu" 連発を Group A / Item A-1 のプレースホルダに (置き換え漏れの本番投入事故を防ぐ)
- `index.mdx` を h1 + intro + h2 + list + Island サンプルのスターターとして意味の通る形に
- Clicker サンプルの `<button>` と `<output>` のレイアウトを `flex items-center gap-4` + `text-xl tabular-nums` に整えて、隣接がぶつからず桁増でも幅が揺れないようにした

**ビルド / lint**

- `eslint-plugin-react` の "React version not specified" 警告を `settings.react.version = "18.3.0"` (Preact 10 JSX runtime と API 互換な React 18 系のスタブ) で抑制。`react.configs.flat.recommended` を jsx/mdx ファイルに絞り込み

**細部**

- `slugify(item.name)` の ID 衝突リスク (同名グループが複数あると `nav-button-{slug}` が重複) を itemIndex 混入で解消
- `<div role="presentation">` の generic role を削除
- Clicker ボタンに `type="button"` を明示
- `useEffect` の依存配列から可変な `ref.current` を外す

## Test plan

- [x] `packages/create-eleventy` の既存テスト (scaffold → pnpm install → pnpm build) が通ることは各コミットで確認済み
- [x] scaffold して `pnpm dev` で開き、ヘッダーメニューをキーボード操作 (Tab / Shift+Tab / Enter / Escape) で確認
- [x] モバイルビューでメニュー開閉、focus 遷移、背景スクロール停止を確認 (playwright-cli で一部確認済み)
- [x] `curl` などで dist/index.html を取得し `<!doctype html>` から始まっているか確認
- [ ] 生成 HTML を Nu Html Checker で検査
- [ ] axe DevTools でランドマーク / ARIA / コントラストを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)