### PR TITLE
feat(eleventy-plugin-preact-island): auto pinning importmap preact version

### DIFF
--- a/packages/eleventy-plugin-preact-island/README.md
+++ b/packages/eleventy-plugin-preact-island/README.md
@@ -52,9 +52,17 @@ That's it. Author client components as `src/**/*.client.jsx` (or `.tsx` / `.js` 
 ### `preactVersion`
 
 - Type: `string`
-- Default: `""` (latest)
+- Default: auto-detected from the installed `preact` (falls back to esm.sh
+  latest with a warning if `preact` cannot be resolved)
 
-Specify the Preact version to use from esm.sh CDN.
+Normally you do not need to set this. The plugin reads the version of `preact`
+installed in your project (from `preact/package.json`) and pins the esm.sh
+import-map URLs to it, so the CDN runtime stays in sync with the SSR/bundle
+side by default.
+
+Set this only to force the CDN side to a different version than the installed
+one (e.g., an emergency rollback of the runtime without touching your
+`package.json`).
 
 ```javascript
 eleventyConfig.addPlugin(preactIsland, {

--- a/packages/eleventy-plugin-preact-island/index.d.ts
+++ b/packages/eleventy-plugin-preact-island/index.d.ts
@@ -2,8 +2,12 @@ import type { UserConfig } from "@11ty/eleventy";
 
 export interface PluginOptions {
   /**
-   * Preact version for esm.sh CDN (e.g., "10.26.4").
-   * If not specified, the latest version will be used.
+   * Override the Preact version used in the esm.sh CDN URL (e.g., "10.26.4").
+   *
+   * Defaults to the version of `preact` installed in the host project
+   * (auto-detected from `preact/package.json`), so the CDN runtime stays in
+   * sync with the SSR/bundle side by default. Set this only to force the CDN
+   * side to a different version than the installed one.
    */
   preactVersion?: string;
   /**

--- a/packages/eleventy-plugin-preact-island/index.js
+++ b/packages/eleventy-plugin-preact-island/index.js
@@ -1,8 +1,25 @@
+import { createRequire } from "node:module";
 import url from "node:url";
 import * as esbuild from "esbuild";
 import fg from "fast-glob";
 import { _setClientModuleResolver } from "./island.js";
 import { createClientModuleResolver, normalizeUrlPrefix } from "./resolver.js";
+
+const require = createRequire(import.meta.url);
+
+// NOTE: peer で入っている preact の package.json から version を取り、
+// import map の esm.sh URL に反映するための解決子。プロセス中に実体が
+// 入れ替わることは無いのでモジュールロード時に一度だけ評価する。
+// 解決に失敗するのは peer が意図的に入っていない (bundle: false 運用等)
+// 例外的なケース。呼び出し側でフォールバックする。
+const resolveInstalledPreactVersion = () => {
+  try {
+    return require("preact/package.json").version;
+  } catch {
+    return null;
+  }
+};
+const installedPreactVersion = resolveInstalledPreactVersion();
 
 /**
  * Eleventy plugin for Preact partial hydration with is-land.
@@ -22,7 +39,10 @@ import { createClientModuleResolver, normalizeUrlPrefix } from "./resolver.js";
  *
  * @param {import("@11ty/eleventy").UserConfig} eleventyConfig
  * @param {Object} [pluginOptions]
- * @param {string} [pluginOptions.preactVersion] - Preact version for esm.sh CDN
+ * @param {string} [pluginOptions.preactVersion] - Override the Preact version
+ *   used in the esm.sh CDN URL. Defaults to the version of `preact` installed
+ *   in the host project (auto-detected from `preact/package.json`). Set this
+ *   only to force the CDN side to a different version than the installed one.
  * @param {boolean} [pluginOptions.bundle=true] - Bundle client entries with
  *   esbuild. Set to `false` to bring your own bundler; the ignore rule,
  *   resolver wiring, is-land.js copy, and script injection stay active.
@@ -34,7 +54,24 @@ export default function (eleventyConfig, pluginOptions = {}) {
     console.log(`[eleventy-plugin-preact-island] WARN: ${e.message}`);
   }
 
-  const { preactVersion = "", bundle = true } = pluginOptions;
+  const { preactVersion, bundle = true } = pluginOptions;
+
+  // 優先順位:
+  //  1. ユーザ指定があればそれを尊重 (CDN 側だけ差し替えたい高度な用途)。
+  //  2. インストール済 preact のバージョンを自動検出できたらそれで pin。
+  //  3. どちらも無い場合は latest フォールバックにするが、SSR/CSR の
+  //     バージョンドリフトが復活するので登録時に一度だけ警告する。
+  let resolvedPreactVersion;
+  if (preactVersion) {
+    resolvedPreactVersion = preactVersion;
+  } else if (installedPreactVersion) {
+    resolvedPreactVersion = installedPreactVersion;
+  } else {
+    resolvedPreactVersion = "";
+    console.warn(
+      "[eleventy-plugin-preact-island] WARN: could not resolve the installed preact version; falling back to latest via esm.sh. Install `preact` (>=10) to pin the CDN version.",
+    );
+  }
 
   // Ride on Eleventy's own input/output directories (normalized, e.g. "./src/").
   const inputDir = eleventyConfig.directories.input;
@@ -105,7 +142,7 @@ export default function (eleventyConfig, pluginOptions = {}) {
   eleventyConfig.addPassthroughCopy({
     [url.fileURLToPath(import.meta.resolve("@11ty/is-land/is-land.js"))]: "/",
   });
-  const preactSuffix = preactVersion ? `@${preactVersion}` : "";
+  const preactSuffix = resolvedPreactVersion ? `@${resolvedPreactVersion}` : "";
 
   const generateImportMap = () => `<script type="importmap">
 {

--- a/packages/eleventy-plugin-preact-island/index.test.js
+++ b/packages/eleventy-plugin-preact-island/index.test.js
@@ -1,9 +1,12 @@
+import { createRequire } from "node:module";
 import { describe, it } from "node:test";
 import assert from "node:assert";
 import { h } from "preact";
 import { render } from "preact-render-to-string";
 import preactIsland from "./index.js";
 import { Island, clientComponent } from "./island.js";
+
+const require = createRequire(import.meta.url);
 
 /**
  * Minimal UserConfig stub carrying only what the plugin actually reads.
@@ -133,6 +136,47 @@ describe("Island plugin importmap ↔ Eleventy pathPrefix", () => {
       "dist/index.html",
     );
     assert.match(html, /"is-land": "\/is-land\.js"/);
+  });
+});
+
+describe("Island plugin importmap ↔ preact バージョン自動検出", () => {
+  it("preactVersion 未指定時は importmap がインストール済 preact のバージョンで pin される", () => {
+    const config = makeEleventyConfigStub({ pathPrefix: undefined });
+    preactIsland(config);
+
+    const html = config._transform(
+      "preact-island-inject",
+      "<html><head></head><body></body></html>",
+      "dist/index.html",
+    );
+    // テスト側でもプラグインと同じ peer 依存の preact を参照するので値は一致する
+    const { version } = require("preact/package.json");
+    assert.ok(
+      html.includes(`https://esm.sh/preact@${version}"`),
+      `expected importmap to pin preact to @${version}, got: ${html}`,
+    );
+    assert.ok(
+      html.includes(`https://esm.sh/preact@${version}/hooks?external=preact`),
+    );
+    assert.ok(
+      html.includes(
+        `https://esm.sh/preact@${version}/jsx-runtime?external=preact`,
+      ),
+    );
+  });
+
+  it("preactVersion 指定時は指定値が優先され、警告は出ない", (t) => {
+    const warn = t.mock.method(console, "warn");
+    const config = makeEleventyConfigStub({ pathPrefix: undefined });
+    preactIsland(config, { preactVersion: "10.20.0" });
+
+    const html = config._transform(
+      "preact-island-inject",
+      "<html><head></head><body></body></html>",
+      "dist/index.html",
+    );
+    assert.ok(html.includes(`https://esm.sh/preact@10.20.0"`));
+    assert.strictEqual(warn.mock.callCount(), 0);
   });
 });
 


### PR DESCRIPTION
## Summary

- `import map` に注入する `preact` / `preact/hooks` / `preact/jsx-runtime` の esm.sh URL を、`preactVersion` 未指定時はこれまでの `latest` からインストール済 preact のバージョン pin に変更。SSR/bundle 側で使う preact と実行時ランタイムのバージョンが暗黙にドリフトする経路を塞ぐ。
- 解決は `createRequire(import.meta.url)("preact/package.json").version` でプラグイン登録時に一度だけ行う。
- `preactVersion` オプションは非推奨化せず、明示指定は CDN 側だけ差し替える override として引き続き尊重する。
- peer が入っていない (`bundle: false` 運用等) 例外ケースは登録時に一度だけ `console.warn` を出して `latest` にフォールバックする。

## Test plan

- [x] `pnpm --filter @tuqulore-inc/eleventy-plugin-preact-island test` (43 pass)
- [x] `pnpm -r test`
- [x] `pnpm lint` / `pnpm format` で差分なし
- [x] CONTRIBUTING の手動テストセットアップで default template を scaffold し、`pnpm build` で生成された HTML の `<script type="importmap">` が `https://esm.sh/preact@10.29.7` を指すこと (scaffold 側の preact 実インストール版に一致)
- [x] `preactVersion: "10.20.0"` を追加した config でビルドし、URL が `preact@10.20.0` に切り替わること、および `console.warn` が発生しないこと
- [x] `pnpm dev` で HMR / Islands の hydrate に regression がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)