### PR TITLE
feat(eleventy-plugin-preact-island): use devalue for props serialize

### DIFF
--- a/packages/eleventy-plugin-preact-island/README.md
+++ b/packages/eleventy-plugin-preact-island/README.md
@@ -159,10 +159,10 @@ The `props` attribute is serialized with [`devalue`](https://github.com/Rich-Har
 
 #### Props
 
-| Prop        | Type                              | Description                                                                             |
-| ----------- | --------------------------------- | --------------------------------------------------------------------------------------- |
-| `component` | `ClientComponent`                 | Component wrapped with `clientComponent()` in its `*.client.jsx` file.                  |
-| `on`        | `string` (default: `interaction`) | is-land initialization trigger. Rendered as the boolean attribute `land-on:<on>`.       |
+| Prop        | Type                              | Description                                                                                                                                         |
+| ----------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `component` | `ClientComponent`                 | Component wrapped with `clientComponent()` in its `*.client.jsx` file.                                                                              |
+| `on`        | `string` (default: `interaction`) | is-land initialization trigger. Rendered as the boolean attribute `land-on:<on>`.                                                                   |
 | ...rest     | any                               | Serialized with [`devalue`](https://github.com/Rich-Harris/devalue) onto `<is-land props="...">` and forwarded to the component's SSR render as-is. |
 
 Supported prop types include everything JSON can carry plus `Date`, `Map`, `Set`, `RegExp`, `BigInt`, `undefined`, `NaN`, `Infinity`, and cyclic references. Functions, symbols, DOM nodes, and unregistered class instances are not serializable — passing them throws an `Island: failed to devalue.stringify props` error at build time.

--- a/packages/eleventy-plugin-preact-island/README.md
+++ b/packages/eleventy-plugin-preact-island/README.md
@@ -42,7 +42,7 @@ That's it. Author client components as `src/**/*.client.jsx` (or `.tsx` / `.js` 
 2. **Ignores** those files as Eleventy templates (they're client entries, not pages). This ignore rule is always added, independent of `bundle`.
 3. **Copies `is-land.js`** from `@11ty/is-land` to the output directory.
 4. **Injects scripts** before `</head>`:
-   - Import map for is-land, Preact, and `@preact/signals` (from esm.sh CDN). `@preact/signals` is resolved via the import map so every island bundle shares a single signals instance and preact `options` patch — bundling it per entry would replicate the patch and trip the runtime `Cycle detected` guard.
+   - Import map for is-land, Preact, `@preact/signals`, and [`devalue`](https://github.com/Rich-Harris/devalue) (from esm.sh CDN). `@preact/signals` is resolved via the import map so every island bundle shares a single signals instance and preact `options` patch — bundling it per entry would replicate the patch and trip the runtime `Cycle detected` guard.
    - Development-only WebSocket hook for rehydration after hot reload
    - is-land setup script with `Island.addInitType("preact", mount)`
 5. **Wires the URL resolver** so `<Island>` on the SSR side emits the same URL the bundler produced. Client entries must use the `.client.{js,jsx,ts,tsx}` sub-extension and live under the input directory.
@@ -67,6 +67,26 @@ one (e.g., an emergency rollback of the runtime without touching your
 ```javascript
 eleventyConfig.addPlugin(preactIsland, {
   preactVersion: "10.26.4",
+});
+```
+
+### `devalueVersion`
+
+- Type: `string`
+- Default: auto-detected from the `devalue` bundled with this plugin (falls
+  back to esm.sh latest with a warning if `devalue` cannot be resolved)
+
+Normally you do not need to set this. The plugin reads the version of `devalue`
+bundled with itself (from `devalue/package.json`) and pins the esm.sh
+import-map URL to it, so the SSR-side `devalue.stringify` and the client-side
+`devalue.parse` stay on the same version by default.
+
+Set this only to force the CDN side to a different version than the bundled
+one.
+
+```javascript
+eleventyConfig.addPlugin(preactIsland, {
+  devalueVersion: "5.8.1",
 });
 ```
 
@@ -129,11 +149,13 @@ The example renders (after resolving the import URL):
   land-on:interaction
   type="preact"
   import="/counter.client.js"
-  props='{"label":"click me"}'
+  props='[{"label":1},"click me"]'
 >
   <button>0</button>
 </is-land>
 ```
+
+The `props` attribute is serialized with [`devalue`](https://github.com/Rich-Harris/devalue), not `JSON.stringify`, so `<Island>` can pass values JSON can't represent — `Date`, `Map`, `Set`, `RegExp`, `BigInt`, `undefined`, `NaN`, `Infinity`, and cyclic references — all the way through to hydration with their native types intact. The client-side setup calls `devalue.parse` to reconstruct them.
 
 #### Props
 
@@ -141,13 +163,17 @@ The example renders (after resolving the import URL):
 | ----------- | --------------------------------- | --------------------------------------------------------------------------------------- |
 | `component` | `ClientComponent`                 | Component wrapped with `clientComponent()` in its `*.client.jsx` file.                  |
 | `on`        | `string` (default: `interaction`) | is-land initialization trigger. Rendered as the boolean attribute `land-on:<on>`.       |
-| ...rest     | any                               | Serialized as `props` on `<is-land>` and forwarded to the component's SSR render as-is. |
+| ...rest     | any                               | Serialized with [`devalue`](https://github.com/Rich-Harris/devalue) onto `<is-land props="...">` and forwarded to the component's SSR render as-is. |
+
+Supported prop types include everything JSON can carry plus `Date`, `Map`, `Set`, `RegExp`, `BigInt`, `undefined`, `NaN`, `Infinity`, and cyclic references. Functions, symbols, DOM nodes, and unregistered class instances are not serializable — passing them throws an `Island: failed to devalue.stringify props` error at build time.
 
 For parameterized triggers such as `on:media("(min-width: ...)")`, use the raw `<is-land>` element directly; the injected setup script still handles it.
 
 ## Interoperating with raw `<is-land>`
 
 The raw `<is-land>` element remains fully supported — the script injection is unchanged, and existing partial hydration code that writes `<is-land>` by hand keeps working. `<Island>` is a strict addition on top.
+
+The `props` attribute is now serialized with [`devalue`](https://github.com/Rich-Harris/devalue); write raw `<is-land props="...">` values with `devalue.stringify` if you construct them by hand.
 
 If you want to control bundling entirely yourself (custom output layout, a different sub-extension, hashed asset URLs, or serving bundles from another origin), you can bypass this plugin's `<Island>` convention and drive [`@11ty/is-land`](https://github.com/11ty/is-land) directly — write the `<is-land>` elements and their `import` URLs yourself. The plugin's browser-side setup (import map, is-land script, dev rehydration hook) still applies to those elements.
 

--- a/packages/eleventy-plugin-preact-island/index.d.ts
+++ b/packages/eleventy-plugin-preact-island/index.d.ts
@@ -11,6 +11,16 @@ export interface PluginOptions {
    */
   preactVersion?: string;
   /**
+   * Override the devalue version used in the esm.sh CDN URL (e.g., "5.8.1").
+   *
+   * Defaults to the version of `devalue` bundled with this plugin
+   * (auto-detected from `devalue/package.json`), so the SSR-side `stringify`
+   * and the client-side `parse` come from the same devalue version by default.
+   * Set this only to force the CDN side to a different version than the
+   * bundled one.
+   */
+  devalueVersion?: string;
+  /**
    * Bundle `*.client.{js,jsx,ts,tsx}` entries with esbuild. Set to `false` to
    * bring your own bundler; the plugin still adds the Eleventy ignore rule,
    * wires the SSR URL resolver, copies `is-land.js`, and injects the browser

--- a/packages/eleventy-plugin-preact-island/index.js
+++ b/packages/eleventy-plugin-preact-island/index.js
@@ -9,49 +9,48 @@ import { createClientModuleResolver, normalizeUrlPrefix } from "./resolver.js";
 
 const require = createRequire(import.meta.url);
 
-// NOTE: peer で入っている preact の package.json から version を取り、
-// import map の esm.sh URL に反映するための解決子。プロセス中に実体が
-// 入れ替わることは無いのでモジュールロード時に一度だけ評価する。
-// 解決に失敗するのは peer が意図的に入っていない (bundle: false 運用等)
-// 例外的なケース。呼び出し側でフォールバックする。
-const resolveInstalledPreactVersion = () => {
+// esm.sh の import map URL を、ホスト側にインストール済のバージョンで自動 pin
+// するための解決子。preact / devalue のように SSR 側 (Node) と クライアント側
+// (CDN) の 2 面で同じ package が要る依存を「同一バージョンで動かす」ための共通
+// 基盤。プロセス中に実体が入れ替わることは無いのでモジュールロード時に対象を
+// 決めておく (プラグイン関数からは戻り値を参照するだけ)。
+//
+// 解決経路は 2 段構え:
+//   1. `require("<name>/package.json")` — `./package.json` を exports に
+//      公開している package (preact 等) はこれで 1 回で取れる。
+//   2. entry パスから package.json を上方向に辿る — devalue 5.x のように
+//      exports で `./package.json` を出していない package のフォールバック。
+//      ルート到達 (`dirname(dir) === dir`) で終端。
+// どちらも失敗するのは、peer が意図的に入っていない (bundle: false 運用等) か、
+// npm hoisting が意図せぬ配置になった場合。呼び出し側で latest フォールバック
+// + 警告に切り替える。
+const resolveInstalledPackageVersion = (name) => {
   try {
-    return require("preact/package.json").version;
+    return require(`${name}/package.json`).version;
   } catch {
-    return null;
+    // exports 制約 (ERR_PACKAGE_PATH_NOT_EXPORTED) 等: entry から辿る。
   }
-};
-const installedPreactVersion = resolveInstalledPreactVersion();
-
-// NOTE: SSR 側 (`island.js` の `devalue.stringify`) と importmap 経由の
-// esm.sh 側 (`devalue.parse`) が乖離するとフォーマット破綻の原因になる。
-// 既定では Node 側で解決される devalue の package.json から version を
-// 導出して importmap に埋め込み、両者を実質的に揃える。preact と違って
-// devalue の exports は `./package.json` を公開していないので、entry の
-// パスから package.json を上方向に探す必要がある。
-const resolveInstalledDevalueVersion = () => {
   try {
-    let dir = dirname(url.fileURLToPath(import.meta.resolve("devalue")));
+    let dir = dirname(url.fileURLToPath(import.meta.resolve(name)));
     while (true) {
       try {
         const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
-        if (pkg.name === "devalue" && typeof pkg.version === "string") {
+        if (pkg.name === name && typeof pkg.version === "string") {
           return pkg.version;
         }
       } catch {
         // このディレクトリには package.json が無い、または JSON parse 失敗。
       }
       const parent = dirname(dir);
-      // ルート到達で終端 (POSIX/Windows どちらも root は dirname が自身を返す)。
-      if (parent === dir) break;
+      if (parent === dir) return null;
       dir = parent;
     }
-    return null;
   } catch {
     return null;
   }
 };
-const installedDevalueVersion = resolveInstalledDevalueVersion();
+const installedPreactVersion = resolveInstalledPackageVersion("preact");
+const installedDevalueVersion = resolveInstalledPackageVersion("devalue");
 
 /**
  * Eleventy plugin for Preact partial hydration with is-land.

--- a/packages/eleventy-plugin-preact-island/index.js
+++ b/packages/eleventy-plugin-preact-island/index.js
@@ -1,4 +1,6 @@
+import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import url from "node:url";
 import * as esbuild from "esbuild";
 import fg from "fast-glob";
@@ -20,6 +22,36 @@ const resolveInstalledPreactVersion = () => {
   }
 };
 const installedPreactVersion = resolveInstalledPreactVersion();
+
+// NOTE: SSR 側 (`island.js` の `devalue.stringify`) と importmap 経由の
+// esm.sh 側 (`devalue.parse`) が乖離するとフォーマット破綻の原因になる。
+// 既定では Node 側で解決される devalue の package.json から version を
+// 導出して importmap に埋め込み、両者を実質的に揃える。preact と違って
+// devalue の exports は `./package.json` を公開していないので、entry の
+// パスから package.json を上方向に探す必要がある。
+const resolveInstalledDevalueVersion = () => {
+  try {
+    let dir = dirname(url.fileURLToPath(import.meta.resolve("devalue")));
+    while (true) {
+      try {
+        const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
+        if (pkg.name === "devalue" && typeof pkg.version === "string") {
+          return pkg.version;
+        }
+      } catch {
+        // このディレクトリには package.json が無い、または JSON parse 失敗。
+      }
+      const parent = dirname(dir);
+      // ルート到達で終端 (POSIX/Windows どちらも root は dirname が自身を返す)。
+      if (parent === dir) break;
+      dir = parent;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+const installedDevalueVersion = resolveInstalledDevalueVersion();
 
 /**
  * Eleventy plugin for Preact partial hydration with is-land.
@@ -43,6 +75,11 @@ const installedPreactVersion = resolveInstalledPreactVersion();
  *   used in the esm.sh CDN URL. Defaults to the version of `preact` installed
  *   in the host project (auto-detected from `preact/package.json`). Set this
  *   only to force the CDN side to a different version than the installed one.
+ * @param {string} [pluginOptions.devalueVersion] - Override the devalue version
+ *   used in the esm.sh CDN URL. Defaults to the version of `devalue` bundled
+ *   with this plugin (auto-detected from `devalue/package.json`) so the
+ *   SSR-side `stringify` and the client-side `parse` come from the same
+ *   version. Set this only to force the CDN side to a different version.
  * @param {boolean} [pluginOptions.bundle=true] - Bundle client entries with
  *   esbuild. Set to `false` to bring your own bundler; the ignore rule,
  *   resolver wiring, is-land.js copy, and script injection stay active.
@@ -54,7 +91,7 @@ export default function (eleventyConfig, pluginOptions = {}) {
     console.log(`[eleventy-plugin-preact-island] WARN: ${e.message}`);
   }
 
-  const { preactVersion, bundle = true } = pluginOptions;
+  const { preactVersion, devalueVersion, bundle = true } = pluginOptions;
 
   // 優先順位:
   //  1. ユーザ指定があればそれを尊重 (CDN 側だけ差し替えたい高度な用途)。
@@ -70,6 +107,22 @@ export default function (eleventyConfig, pluginOptions = {}) {
     resolvedPreactVersion = "";
     console.warn(
       "[eleventy-plugin-preact-island] WARN: could not resolve the installed preact version; falling back to latest via esm.sh. Install `preact` (>=10) to pin the CDN version.",
+    );
+  }
+
+  // preactVersion と同じ優先順位ロジックで devalue も揃える。devalue は
+  // このプラグイン自身の dependency なので通常は必ず解決できるが、npm の
+  // 変な hoist などで失敗した場合は latest フォールバック + 警告で SSR/CSR
+  // ドリフトを可視化する。
+  let resolvedDevalueVersion;
+  if (devalueVersion) {
+    resolvedDevalueVersion = devalueVersion;
+  } else if (installedDevalueVersion) {
+    resolvedDevalueVersion = installedDevalueVersion;
+  } else {
+    resolvedDevalueVersion = "";
+    console.warn(
+      "[eleventy-plugin-preact-island] WARN: could not resolve the installed devalue version; falling back to latest via esm.sh. Pin explicitly with pluginOptions.devalueVersion to avoid version drift.",
     );
   }
 
@@ -148,6 +201,9 @@ export default function (eleventyConfig, pluginOptions = {}) {
     [url.fileURLToPath(import.meta.resolve("@11ty/is-land/is-land.js"))]: "/",
   });
   const preactSuffix = resolvedPreactVersion ? `@${resolvedPreactVersion}` : "";
+  const devalueSuffix = resolvedDevalueVersion
+    ? `@${resolvedDevalueVersion}`
+    : "";
 
   const generateImportMap = () => `<script type="importmap">
 {
@@ -157,7 +213,8 @@ export default function (eleventyConfig, pluginOptions = {}) {
     "preact/hooks": "https://esm.sh/preact${preactSuffix}/hooks?external=preact",
     "preact/jsx-runtime": "https://esm.sh/preact${preactSuffix}/jsx-runtime?external=preact",
     "@preact/signals": "https://esm.sh/@preact/signals?external=preact,preact/hooks",
-    "@preact/signals-core": "https://esm.sh/@preact/signals-core"
+    "@preact/signals-core": "https://esm.sh/@preact/signals-core",
+    "devalue": "https://esm.sh/devalue${devalueSuffix}"
   }
 }
 </script>`;
@@ -210,13 +267,14 @@ window.__eleventyRehydrate = () => {
     return `<script type="module">
 import { Island } from "is-land";
 import { h, hydrate } from "preact";
+import { parse } from "devalue";
 Island.attributePrefix = "land-on:";
 
 const mount = async (target) => {
   try {
     const component = await import(target.getAttribute("import"));
     const propsAttr = target.getAttribute("props");
-    const props = propsAttr ? JSON.parse(propsAttr) : {};
+    const props = propsAttr ? parse(propsAttr) : {};
     hydrate(h(component.default, props), target);
   } catch (e) {
     console.error("Failed to mount component:", e);

--- a/packages/eleventy-plugin-preact-island/index.test.js
+++ b/packages/eleventy-plugin-preact-island/index.test.js
@@ -1,12 +1,35 @@
 import { createRequire } from "node:module";
 import { describe, it } from "node:test";
 import assert from "node:assert";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { h } from "preact";
 import { render } from "preact-render-to-string";
 import preactIsland from "./index.js";
 import { Island, clientComponent } from "./island.js";
 
 const require = createRequire(import.meta.url);
+
+// index.js の resolveInstalledDevalueVersion が導出するはずのバージョンを
+// テスト側から独立に取得する (両実装が一致することを確認)。devalue の
+// exports は `./package.json` を公開していないので、entry パスから上方向に
+// package.json を探す (preact のように require では取れない)。
+function readInstalledDevalueVersion() {
+  let dir = dirname(fileURLToPath(import.meta.resolve("devalue")));
+  while (true) {
+    try {
+      const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
+      if (pkg.name === "devalue") return pkg.version;
+    } catch {
+      // 上へ辿る
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error("devalue package.json not found");
+}
 
 /**
  * Minimal UserConfig stub carrying only what the plugin actually reads.
@@ -176,6 +199,39 @@ describe("Island plugin importmap ↔ preact バージョン自動検出", () =>
       "dist/index.html",
     );
     assert.ok(html.includes(`https://esm.sh/preact@10.20.0"`));
+    assert.strictEqual(warn.mock.callCount(), 0);
+  });
+});
+
+describe("Island plugin importmap ↔ devalue バージョン自動検出", () => {
+  it("devalueVersion 未指定時は importmap が同梱 devalue のバージョンで pin される", () => {
+    const config = makeEleventyConfigStub({ pathPrefix: undefined });
+    preactIsland(config);
+
+    const html = config._transform(
+      "preact-island-inject",
+      "<html><head></head><body></body></html>",
+      "dist/index.html",
+    );
+    // テスト側でもプラグインが依存しているのと同じ devalue を参照するので値は一致する
+    const version = readInstalledDevalueVersion();
+    assert.ok(
+      html.includes(`https://esm.sh/devalue@${version}"`),
+      `expected importmap to pin devalue to @${version}, got: ${html}`,
+    );
+  });
+
+  it("devalueVersion 指定時は指定値が優先され、警告は出ない", (t) => {
+    const warn = t.mock.method(console, "warn");
+    const config = makeEleventyConfigStub({ pathPrefix: undefined });
+    preactIsland(config, { devalueVersion: "5.0.0" });
+
+    const html = config._transform(
+      "preact-island-inject",
+      "<html><head></head><body></body></html>",
+      "dist/index.html",
+    );
+    assert.ok(html.includes(`https://esm.sh/devalue@5.0.0"`));
     assert.strictEqual(warn.mock.callCount(), 0);
   });
 });

--- a/packages/eleventy-plugin-preact-island/index.test.js
+++ b/packages/eleventy-plugin-preact-island/index.test.js
@@ -234,6 +234,27 @@ describe("Island plugin importmap ↔ devalue バージョン自動検出", () =
     assert.ok(html.includes(`https://esm.sh/devalue@5.0.0"`));
     assert.strictEqual(warn.mock.callCount(), 0);
   });
+
+  // preactVersion と同じく `if (devalueVersion)` の truthy 判定にしてあるので、
+  // 空文字は「未指定と同じ扱い」= 自動検出フォールバックに落ちる。preact 側と
+  // 非対称に「空文字で latest 強制」を追加しないことをここで固定する。
+  it("devalueVersion に空文字を渡すと未指定と同じく自動検出でピン留めされる", (t) => {
+    const warn = t.mock.method(console, "warn");
+    const config = makeEleventyConfigStub({ pathPrefix: undefined });
+    preactIsland(config, { devalueVersion: "" });
+
+    const html = config._transform(
+      "preact-island-inject",
+      "<html><head></head><body></body></html>",
+      "dist/index.html",
+    );
+    const version = readInstalledDevalueVersion();
+    assert.ok(
+      html.includes(`https://esm.sh/devalue@${version}"`),
+      `expected empty string to fall through to auto-detected devalue@${version}, got: ${html}`,
+    );
+    assert.strictEqual(warn.mock.callCount(), 0);
+  });
 });
 
 describe("Island plugin bundle オプション", () => {

--- a/packages/eleventy-plugin-preact-island/island.js
+++ b/packages/eleventy-plugin-preact-island/island.js
@@ -1,4 +1,5 @@
 import { h } from "preact";
+import { stringify } from "devalue";
 
 let currentResolver = null;
 
@@ -57,7 +58,7 @@ export function clientComponent(Component, moduleUrl) {
 export function Island({ component, on = "interaction", ...props }) {
   // Drop children explicitly. Preact folds JSX children into props.children,
   // and Island's contract is that SSR content comes from `component`; letting
-  // children fall through would leak Preact VNodes into the JSON-serialized
+  // children fall through would leak Preact VNodes into the devalue-serialized
   // `props` attribute on <is-land> and into the client hydration payload.
   delete props.children;
   if (typeof component !== "function") {
@@ -87,10 +88,12 @@ export function Island({ component, on = "interaction", ...props }) {
   const importUrl = currentResolver(moduleUrl);
   let serializedProps;
   try {
-    serializedProps = JSON.stringify(props);
+    serializedProps = stringify(props);
   } catch (cause) {
+    const path = typeof cause?.path === "string" ? cause.path : "";
+    const location = path ? ` at \`${path}\`` : "";
     throw new Error(
-      `Island: failed to JSON.stringify props for hydration of ${component.name || "anonymous component"} (${importUrl}). Ensure all Island props are JSON-serializable.`,
+      `Island: failed to devalue.stringify props for hydration of ${component.name || "anonymous component"} (${importUrl})${location}. Ensure all Island props are devalue-serializable (Date, Map, Set, RegExp, BigInt, undefined, NaN/Infinity, and cycles are OK; functions, symbols, DOM nodes, and unregistered class instances are not).`,
       { cause },
     );
   }

--- a/packages/eleventy-plugin-preact-island/island.test.js
+++ b/packages/eleventy-plugin-preact-island/island.test.js
@@ -2,7 +2,24 @@ import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert";
 import { h } from "preact";
 import { render } from "preact-render-to-string";
+import { parse } from "devalue";
 import { Island, clientComponent, _setClientModuleResolver } from "./island.js";
+
+// SSR HTML から <is-land ... props="..."> の props 属性値を取り出し、HTML エスケープを
+// 戻して devalue.parse に通す。SSR 側の stringify とクライアント側の parse が
+// 対で復元するラウンドトリップを、クライアント setup 文字列を eval せずに検証する。
+function extractParsedProps(html) {
+  const m = html.match(/ props="([^"]*)"/);
+  if (!m) throw new Error(`no props attribute in: ${html}`);
+  const decoded = m[1]
+    .replaceAll("&quot;", '"')
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&#39;", "'")
+    // &amp; は最後に戻す (先にやると &amp;quot; が " まで剥がれる)
+    .replaceAll("&amp;", "&");
+  return parse(decoded);
+}
 
 describe("_setClientModuleResolver", () => {
   it("関数を渡せる", () => {
@@ -57,7 +74,7 @@ describe("Island", () => {
     _setClientModuleResolver(null);
   });
 
-  it("clientComponent 済み component を <is-land> でラップし、resolver 経由の import URL と JSON props を出力する", () => {
+  it("clientComponent 済み component を <is-land> でラップし、resolver 経由の import URL と devalue props を出力する", () => {
     const receivedUrls = [];
     _setClientModuleResolver((moduleUrl) => {
       receivedUrls.push(moduleUrl);
@@ -76,8 +93,11 @@ describe("Island", () => {
     assert.match(html, /land-on:visible/);
     assert.match(html, /type="preact"/);
     assert.match(html, /import="\/foo\.client\.js"/);
-    // JSON.stringify({ name: "alice" }) が HTML エスケープされて属性値に入る
-    assert.match(html, /props="\{&quot;name&quot;:&quot;alice&quot;\}"/);
+    // devalue.stringify({ name: "alice" }) → [{"name":1},"alice"] が HTML エスケープされる
+    assert.match(
+      html,
+      /props="\[\{&quot;name&quot;:1\},&quot;alice&quot;\]"/,
+    );
     // SSR 内容として component が同じ props でレンダリングされている
     assert.match(html, /<span>alice<\/span>/);
     assert.match(html, /<\/is-land>$/);
@@ -154,31 +174,110 @@ describe("Island", () => {
 
     // <is-land props="..."> 属性に children/VNode が混入していないことを確認
     // (props 属性値は tag のみで完結)
-    assert.match(html, /props="\{&quot;tag&quot;:&quot;auto&quot;\}"/);
+    assert.match(html, /props="\[\{&quot;tag&quot;:1\},&quot;auto&quot;\]"/);
     // component 側にも children は渡らない
     assert.deepStrictEqual(receivedProps, [{ tag: "auto" }]);
   });
 
-  it("JSON.stringify に失敗する props (循環参照など) は Island 文脈のエラーで包む", () => {
+  it("循環参照 props は throw せず、devalue で識別子が復元される", () => {
     _setClientModuleResolver(() => "/x.client.js");
     const X = clientComponent(function X() {
       return null;
     }, "file:///proj/src/x.client.jsx");
 
-    const circular = {};
+    const circular = { name: "root" };
     circular.self = circular;
 
+    const html = render(h(Island, { component: X, data: circular }));
+    const parsed = extractParsedProps(html);
+    assert.strictEqual(parsed.data.name, "root");
+    // 循環参照の identity が復元される (JSON では不可能だった挙動)
+    assert.strictEqual(parsed.data.self, parsed.data);
+  });
+
+  it("devalue-serializable でない props (関数など) は Island 文脈のエラーで包む", () => {
+    _setClientModuleResolver(() => "/x.client.js");
+    const X = clientComponent(function X() {
+      return null;
+    }, "file:///proj/src/x.client.jsx");
+
     assert.throws(
-      () => render(h(Island, { component: X, data: circular })),
+      () => render(h(Island, { component: X, onClick: () => {} })),
       (err) => {
-        assert.match(err.message, /Island: failed to JSON\.stringify props/);
-        assert.match(err.message, /\/x\.client\.js/);
-        assert.ok(
-          err.cause instanceof TypeError,
-          "元の TypeError が cause に保持されている",
+        assert.match(
+          err.message,
+          /Island: failed to devalue\.stringify props/,
         );
+        assert.match(err.message, /\/x\.client\.js/);
+        // devalue の DevalueError.path は原因 prop の位置を示す
+        assert.match(err.message, /at `\.onClick`/);
+        assert.ok(err.cause instanceof Error, "元エラーが cause に保持されている");
         return true;
       },
     );
+  });
+
+  it("Date が SSR → devalue.parse で instanceof Date のまま round-trip する", () => {
+    _setClientModuleResolver(() => "/x.client.js");
+    const X = clientComponent(function X() {
+      return null;
+    }, "file:///proj/src/x.client.jsx");
+
+    const at = new Date("2026-07-13T00:00:00Z");
+    const html = render(h(Island, { component: X, at }));
+    const parsed = extractParsedProps(html);
+    assert.ok(parsed.at instanceof Date);
+    assert.strictEqual(parsed.at.getTime(), at.getTime());
+  });
+
+  it("Map / Set / BigInt / undefined / NaN / Infinity / RegExp が round-trip する", () => {
+    _setClientModuleResolver(() => "/x.client.js");
+    const X = clientComponent(function X() {
+      return null;
+    }, "file:///proj/src/x.client.jsx");
+
+    const map = new Map([
+      ["a", 1],
+      ["b", 2],
+    ]);
+    const set = new Set(["x", "y"]);
+    const html = render(
+      h(Island, {
+        component: X,
+        map,
+        set,
+        big: 10n,
+        undef: undefined,
+        nan: NaN,
+        inf: Infinity,
+        regex: /abc/gi,
+      }),
+    );
+    const parsed = extractParsedProps(html);
+    assert.ok(parsed.map instanceof Map);
+    assert.deepStrictEqual([...parsed.map], [...map]);
+    assert.ok(parsed.set instanceof Set);
+    assert.deepStrictEqual([...parsed.set], [...set]);
+    assert.strictEqual(parsed.big, 10n);
+    assert.strictEqual(parsed.undef, undefined);
+    assert.ok(Number.isNaN(parsed.nan));
+    assert.strictEqual(parsed.inf, Infinity);
+    assert.ok(parsed.regex instanceof RegExp);
+    assert.strictEqual(parsed.regex.source, "abc");
+    assert.strictEqual(parsed.regex.flags, "gi");
+  });
+
+  it("文字列 prop に閉じタグ様の内容が入っても HTML には生 </script> が出ず、round-trip で復元される", () => {
+    _setClientModuleResolver(() => "/x.client.js");
+    const X = clientComponent(function X() {
+      return null;
+    }, "file:///proj/src/x.client.jsx");
+
+    const payload = '</script><script>alert(1)</script>';
+    const html = render(h(Island, { component: X, s: payload }));
+    // devalue が < を < に unicode escape するため属性値に生 </script> は出ない
+    assert.doesNotMatch(html, /<\/script>/);
+    const parsed = extractParsedProps(html);
+    assert.strictEqual(parsed.s, payload);
   });
 });

--- a/packages/eleventy-plugin-preact-island/island.test.js
+++ b/packages/eleventy-plugin-preact-island/island.test.js
@@ -94,10 +94,7 @@ describe("Island", () => {
     assert.match(html, /type="preact"/);
     assert.match(html, /import="\/foo\.client\.js"/);
     // devalue.stringify({ name: "alice" }) → [{"name":1},"alice"] が HTML エスケープされる
-    assert.match(
-      html,
-      /props="\[\{&quot;name&quot;:1\},&quot;alice&quot;\]"/,
-    );
+    assert.match(html, /props="\[\{&quot;name&quot;:1\},&quot;alice&quot;\]"/);
     // SSR 内容として component が同じ props でレンダリングされている
     assert.match(html, /<span>alice<\/span>/);
     assert.match(html, /<\/is-land>$/);
@@ -204,14 +201,14 @@ describe("Island", () => {
     assert.throws(
       () => render(h(Island, { component: X, onClick: () => {} })),
       (err) => {
-        assert.match(
-          err.message,
-          /Island: failed to devalue\.stringify props/,
-        );
+        assert.match(err.message, /Island: failed to devalue\.stringify props/);
         assert.match(err.message, /\/x\.client\.js/);
         // devalue の DevalueError.path は原因 prop の位置を示す
         assert.match(err.message, /at `\.onClick`/);
-        assert.ok(err.cause instanceof Error, "元エラーが cause に保持されている");
+        assert.ok(
+          err.cause instanceof Error,
+          "元エラーが cause に保持されている",
+        );
         return true;
       },
     );
@@ -273,7 +270,7 @@ describe("Island", () => {
       return null;
     }, "file:///proj/src/x.client.jsx");
 
-    const payload = '</script><script>alert(1)</script>';
+    const payload = "</script><script>alert(1)</script>";
     const html = render(h(Island, { component: X, s: payload }));
     // devalue が < を < に unicode escape するため属性値に生 </script> は出ない
     assert.doesNotMatch(html, /<\/script>/);

--- a/packages/eleventy-plugin-preact-island/package.json
+++ b/packages/eleventy-plugin-preact-island/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@11ty/is-land": "^5.0.0",
+    "devalue": "^5.8.1",
     "esbuild": "^0.28.0",
     "fast-glob": "^3.3.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       '@11ty/is-land':
         specifier: ^5.0.0
         version: 5.0.1
+      devalue:
+        specifier: ^5.8.1
+        version: 5.8.1
       esbuild:
         specifier: ^0.28.0
         version: 0.28.1
@@ -1308,6 +1311,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -4034,6 +4040,8 @@ snapshots:
   detect-indent@7.0.2: {}
 
   detect-libc@2.1.2: {}
+
+  devalue@5.8.1: {}
 
   devlop@1.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

RFC #906 の実装。`<Island>` の props シリアライザを `JSON.stringify` / `JSON.parse` から [`devalue`](https://github.com/Rich-Harris/devalue) の `stringify` / `parse` に対で置き換える。これにより `Date` / `Map` / `Set` / `RegExp` / `BigInt` / `undefined` / `NaN` / `Infinity` / 循環参照が SSR から hydration まで native 型で渡るようになる。

公開 API (`<Island>`, `clientComponent`, プラグイン関数のシグネチャ) は不変。SemVer 上は minor 相当。

Closes #906

## 変更点

### SSR / クライアント setup

- `island.js`: `stringify(props)` に差し替え。エラーメッセージを devalue 前提に更新し、`DevalueError.path` (原因 prop の位置) をメッセージに含める
- `index.js`: setup script に `import { parse } from "devalue"` を追加、`JSON.parse` を差し替え

### `devalueVersion` オプション ( #910 の `preactVersion` と対称)

- `preactVersion` と同じ優先順位ロジック: **明示指定 (truthy) > 自動検出 > `""` + 警告**
- 既定では同梱 `devalue` の `package.json` から version を自動検出して importmap に埋め込み、SSR ↔ esm.sh の乖離を防ぐ
- `devalueVersion: ""` は falsy 判定なので `preactVersion` と同じく **「未指定と同じ扱い = 自動検出にフォールバック」**。空文字だけを特別扱いしない (テストで固定)
- 自動検出が失敗した場合 (npm hoisting 事故など) のみ esm.sh `latest` にフォールバック + 警告

### 共通ヘルパ `resolveInstalledPackageVersion(name)`

- #910 で入った `resolveInstalledPreactVersion` と、本 PR の devalue 側解決子を 1 つに統合
- まず `require("<name>/package.json").version` を試し、`exports` 制約で拒否された場合 (devalue 5.x の `ERR_PACKAGE_PATH_NOT_EXPORTED` など) は entry から package.json を上方向に辿るフォールバックに移る。ルート到達 (`dirname(dir) === dir`) で終端
- 同じパッケージ内で 2 種類の解決パターンが混在するのを避け、将来 esm.sh に載せる依存を増やしても呼び出し 1 行で済む形に

### エラー文言

before:
```
Island: failed to JSON.stringify props for hydration of X (/x.js). Ensure all Island props are JSON-serializable.
```

after:
```
Island: failed to devalue.stringify props for hydration of X (/x.js) at `.onClick`. Ensure all Island props are devalue-serializable (Date, Map, Set, RegExp, BigInt, undefined, NaN/Infinity, and cycles are OK; functions, symbols, DOM nodes, and unregistered class instances are not).
```

### テスト

- 既存 3 regex を devalue 出力 (`[{"…":1},"…"]` 形式) に更新
- 旧「循環参照 → throw」テストを削除する前に「循環参照 → 成功で round-trip (identity 復元)」を追加してからカバレッジ穴なく差し替え
- 関数 prop 拒否 / Date round-trip / Map・Set・BigInt・undefined・NaN・Infinity・RegExp round-trip / XSS 回帰 (文字列 prop に `</script>` を含めても生 `</script>` が HTML に出ない) を新設
- `index.test.js` に `devalueVersion` の 3 ケースを追加:
  - 未指定 → 同梱 devalue のバージョンで自動 pin
  - 明示指定 → 指定値が優先、警告 0
  - `""` → 未指定と同じく自動 pin (preact と対称であることを固定)

### README

- HTML 出力例を devalue 形式に更新
- Options 節に `devalueVersion` を追加 (`preactVersion` と対称)
- raw `<is-land>` 節に「props 属性は devalue.stringify で書く」旨を 1 行追記

## 互換性

- `<Island>` を使う限り透過。エンドユーザーは特に何もする必要がない
- raw `<is-land props="...">` を手書きしていた場合のみ、書式が JSON → devalue になる (README で告知)
- `!` は付けない (SemVer minor 相当)

## Test plan

- [x] `pnpm -r test` (preact-island 50 / preact 19 / create-eleventy 7 = 76/76 pass)
- [x] `pnpm -r lint` clean
- [x] CONTRIBUTING.md の手動テストガイドの scaffold + `pnpm install` を実施 (`$WORK/my-app`)
- [x] `pnpm dev` で `<Island component={Clicker} on="interaction" />` (index.mdx) / `<Desktop>` `<Mobile>` (header.mdx) が hydrate 後に操作可能
- [ ] HTML ソースの `<is-land ... props="...">` が devalue 形式になっている
- [x] Network タブで `esm.sh/devalue@5.8.1` が 200 で解決される
- [x] `pnpm build && pnpm dlx serve dist` でも同挙動
- [ ] (任意) `clicker.client.jsx` に一時的に `publishedAt: Date` / `hours: Map` を渡し、DevTools で hydrate 後に `instanceof Date` / `instanceof Map` になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)