### PR TITLE
feat(create-eleventy): use \@preact/signals by default

### DIFF
--- a/packages/create-eleventy/templates/default/README.md
+++ b/packages/create-eleventy/templates/default/README.md
@@ -119,11 +119,11 @@ Eleventyテンプレートの参照先です。
 ```jsx
 // src/counter.client.jsx
 import { clientComponent } from "@tuqulore-inc/eleventy-preset/island";
-import { useState } from "preact/hooks";
+import { useSignal } from "@preact/signals";
 
 function Counter(props) {
-  const [n, setN] = useState(props.initial ?? 0);
-  return <button onClick={() => setN(n + 1)}>{n}</button>;
+  const n = useSignal(props.initial ?? 0);
+  return <button onClick={() => n.value++}>{n}</button>;
 }
 
 export default clientComponent(Counter, import.meta.url);

--- a/packages/create-eleventy/templates/default/package.json
+++ b/packages/create-eleventy/templates/default/package.json
@@ -19,6 +19,7 @@
     "@iconify/json": "^2.2.90",
     "@iconify/tailwind4": "^1.0.6",
     "@jumpu-ui/tailwindcss": "3.0.1",
+    "@preact/signals": "^2.9.3",
     "@tailwindcss/postcss": "^4.0.14",
     "@tailwindcss/typography": "0.5.20",
     "@tuqulore-inc/eleventy-preset": "^5.0.1",

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
@@ -1,26 +1,31 @@
 import { clientComponent } from "@tuqulore-inc/eleventy-preset/island";
-import { useState, useRef, useEffect } from "preact/hooks";
+import { useSignal, useSignalEffect } from "@preact/signals";
+import { useRef } from "preact/hooks";
 import slugify from "slugify";
 import { twMerge } from "tailwind-merge";
 
 function MenuList(props) {
-  const [open, setOpen] = useState(false);
-  const [visible, setVisible] = useState(open);
-  const handleTransitionStart = () => open && setVisible(true);
-  const handleTransitionEnd = () => !open && setVisible(false);
+  const open = useSignal(false);
+  const visible = useSignal(open.value);
+  const handleTransitionStart = () => {
+    if (open.value) visible.value = true;
+  };
+  const handleTransitionEnd = () => {
+    if (!open.value) visible.value = false;
+  };
   const ref = useRef(null);
   const buttonRef = useRef(null);
   const slug = `${slugify(props.item.name)}-${props.index}`;
-  useEffect(() => {
-    if (!open) return;
+  useSignalEffect(() => {
+    if (!open.value) return;
     const clickHandler = (e) => {
       if (ref.current?.contains(e.target)) return;
-      setOpen(false);
+      open.value = false;
     };
     const keyHandler = (e) => {
       if (e.key !== "Escape") return;
       if (!ref.current?.contains(e.target)) return;
-      setOpen(false);
+      open.value = false;
       buttonRef.current?.focus();
     };
     document.addEventListener("click", clickHandler);
@@ -29,23 +34,23 @@ function MenuList(props) {
       document.removeEventListener("click", clickHandler);
       document.removeEventListener("keydown", keyHandler);
     };
-  }, [open]);
+  });
   return (
     <div
       ref={ref}
       onFocusOut={(e) => {
         if (ref.current?.contains(e.relatedTarget)) return;
-        setOpen(false);
+        open.value = false;
       }}
     >
       <button
         id={`nav-button-${slug}`}
         ref={buttonRef}
         aria-controls={`nav-menu-${slug}`}
-        aria-expanded={open}
+        aria-expanded={open.value}
         class="jumpu-text-button"
         type="button"
-        onClick={() => setOpen(!open)}
+        onClick={() => (open.value = !open.value)}
       >
         {props.item.name}
       </button>
@@ -55,8 +60,8 @@ function MenuList(props) {
         class={twMerge(
           "jumpu-card absolute top-full left-1/2 max-h-[50vh] -translate-x-1/2 overflow-y-auto p-2",
           "translate-y-2 transition duration-75 ease-in-out",
-          !open && "translate-y-[2.5%] scale-95 opacity-0",
-          open || visible ? "visible" : "invisible",
+          !open.value && "translate-y-[2.5%] scale-95 opacity-0",
+          open.value || visible.value ? "visible" : "invisible",
         )}
         onTransitionStart={handleTransitionStart}
         onTransitionEnd={handleTransitionEnd}

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
@@ -1,20 +1,21 @@
 import { clientComponent } from "@tuqulore-inc/eleventy-preset/island";
-import { useEffect, useRef, useState } from "preact/hooks";
+import { useSignal, useSignalEffect } from "@preact/signals";
+import { useRef } from "preact/hooks";
 import { twMerge } from "tailwind-merge";
 
 function Mobile(props) {
-  const [open, setOpen] = useState(false);
+  const open = useSignal(false);
   const openButtonRef = useRef(null);
   const closeButtonRef = useRef(null);
-  useEffect(() => {
-    if (!open) return;
+  useSignalEffect(() => {
+    if (!open.value) return;
     closeButtonRef.current?.focus();
     // NOTE: メニュー表示中は背景 (html) のスクロールを止め、モバイルで
     // メニューをスクロールしたつもりが背後のページも動く事故を防ぐ。
     document.documentElement.classList.add("overflow-hidden");
     const handler = (e) => {
       if (e.key !== "Escape") return;
-      setOpen(false);
+      open.value = false;
       openButtonRef.current?.focus();
     };
     document.addEventListener("keydown", handler);
@@ -22,29 +23,31 @@ function Mobile(props) {
       document.removeEventListener("keydown", handler);
       document.documentElement.classList.remove("overflow-hidden");
     };
-  }, [open]);
+  });
   return (
     <div class={props.class}>
       <button
         id="nav-button-mobile"
         ref={openButtonRef}
         aria-controls="nav-menu-mobile"
-        aria-expanded={open}
-        aria-label={open ? "Close navigation menu" : "Open navigation menu"}
+        aria-expanded={open.value}
+        aria-label={
+          open.value ? "Close navigation menu" : "Open navigation menu"
+        }
         class="jumpu-icon-button h-12 w-12 text-2xl"
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => (open.value = !open.value)}
       >
         <span class="icon-[material-symbols--menu]"></span>
       </button>
       <nav
         id="nav-menu-mobile"
         aria-label="Global navigation"
-        inert={!open}
+        inert={!open.value}
         class={twMerge(
           "fixed top-0 left-0 h-screen w-screen overflow-y-auto overscroll-contain bg-white",
           "transition duration-150 ease-in-out",
-          open ? "translate-x-0" : "translate-x-full",
+          open.value ? "translate-x-0" : "translate-x-full",
         )}
       >
         <button
@@ -53,7 +56,7 @@ function Mobile(props) {
           aria-label="Close navigation menu"
           type="button"
           onClick={() => {
-            setOpen(false);
+            open.value = false;
             openButtonRef.current?.focus();
           }}
         >

--- a/packages/create-eleventy/templates/default/src/clicker.client.jsx
+++ b/packages/create-eleventy/templates/default/src/clicker.client.jsx
@@ -1,15 +1,15 @@
 import { clientComponent } from "@tuqulore-inc/eleventy-preset/island";
-import { useState } from "preact/hooks";
+import { useSignal } from "@preact/signals";
 
 function Clicker() {
-  const [counter, setCounter] = useState(0);
+  const counter = useSignal(0);
 
   return (
     <div class="flex items-center gap-4">
       <button
         type="button"
         class="jumpu-button"
-        onClick={() => setCounter(counter + 1)}
+        onClick={() => counter.value++}
       >
         Count
       </button>

--- a/packages/eleventy-plugin-preact-island/README.md
+++ b/packages/eleventy-plugin-preact-island/README.md
@@ -42,7 +42,7 @@ That's it. Author client components as `src/**/*.client.jsx` (or `.tsx` / `.js` 
 2. **Ignores** those files as Eleventy templates (they're client entries, not pages). This ignore rule is always added, independent of `bundle`.
 3. **Copies `is-land.js`** from `@11ty/is-land` to the output directory.
 4. **Injects scripts** before `</head>`:
-   - Import map for is-land and Preact (from esm.sh CDN)
+   - Import map for is-land, Preact, and `@preact/signals` (from esm.sh CDN). `@preact/signals` is resolved via the import map so every island bundle shares a single signals instance and preact `options` patch — bundling it per entry would replicate the patch and trip the runtime `Cycle detected` guard.
    - Development-only WebSocket hook for rehydration after hot reload
    - is-land setup script with `Island.addInitType("preact", mount)`
 5. **Wires the URL resolver** so `<Island>` on the SSR side emits the same URL the bundler produced. Client entries must use the `.client.{js,jsx,ts,tsx}` sub-extension and live under the input directory.

--- a/packages/eleventy-plugin-preact-island/index.js
+++ b/packages/eleventy-plugin-preact-island/index.js
@@ -85,7 +85,12 @@ export default function (eleventyConfig, pluginOptions = {}) {
       const options = {
         bundle: true,
         entryPoints,
-        external: ["preact"],
+        // NOTE: `@preact/signals` は preact の `options` オブジェクトを patch する。
+        // client bundle ごとに signals を同梱すると patch と signal graph が bundle
+        // 数ぶん複製されて Cycle detected を誤発火する。external + import map で
+        // 単一インスタンスに寄せる。`@preact/signals-core` も signals が外部参照
+        // する前提で同様に external 化する。
+        external: ["preact", "@preact/signals", "@preact/signals-core"],
         format: "esm",
         jsx: "automatic",
         jsxImportSource: "preact",
@@ -113,7 +118,9 @@ export default function (eleventyConfig, pluginOptions = {}) {
     "is-land": "${urlPrefix}is-land.js",
     "preact": "https://esm.sh/preact${preactSuffix}",
     "preact/hooks": "https://esm.sh/preact${preactSuffix}/hooks?external=preact",
-    "preact/jsx-runtime": "https://esm.sh/preact${preactSuffix}/jsx-runtime?external=preact"
+    "preact/jsx-runtime": "https://esm.sh/preact${preactSuffix}/jsx-runtime?external=preact",
+    "@preact/signals": "https://esm.sh/@preact/signals?external=preact,preact/hooks",
+    "@preact/signals-core": "https://esm.sh/@preact/signals-core"
   }
 }
 </script>`;


### PR DESCRIPTION
## Summary
- create-eleventy の default テンプレート 3 ファイル (clicker / header/desktop / header/mobile) を `useState` / `useEffect` から `@preact/signals` の `useSignal` / `useSignalEffect` に移行
- `eleventy-plugin-preact-island` で `@preact/signals` / `@preact/signals-core` を esbuild external + import map 化し、複数 island bundle 間で単一 signals インスタンス / 単一 preact `options` patch を共有 (bundle 複製が `Cycle detected` を誤発火する挙動への対処)
- テンプレートおよびプラグインの README を更新

## 背景
`@preact/signals` は preact の `options` オブジェクトを patch して依存追跡を行う。Island 構成では `.client.jsx` ごとに esbuild で個別 bundle されるため、signals を bundle にまとめると 1 ページ内で複数の signals モジュールが並走し、patch と signal graph が bundle 数ぶん複製されて hydrate 時に `Failed to mount component: Error: Cycle detected` を誤発火する。import map で単一インスタンスに寄せる必要がある。

## 変更方針の要点
- `useState` → `useSignal`、setter は `signal.value = ...` に統一
- `useEffect(..., [open])` → `useSignalEffect`。冒頭 `if (!open.value) return` で「open が false↔true でのみ登録/クリーンアップ」というライフサイクル同等性を維持
- JSX テキストは bare (`{counter}`) で自動サブスクリプション、属性は `.value` 明示 (`twMerge` や `?:` に signal オブジェクトを渡すと常時 truthy になり判定が壊れるため)
- `useRef` は据え置き

## Test plan (CONTRIBUTING §手動テストガイドを実施)
- [x] `pnpm lint` / `pnpm -r test` / `prettier --check .` 緑
- [x] `packages/create-eleventy` templates.test.js 7/7 pass (scaffold → install → build 完走、`dist/**/*.client.js` 3 本、`<is-land import=\"/clicker.client.js\">` 参照)
- [x] `packages/eleventy-plugin-preact-island` テスト 41/41 pass (既存 import map assertion 含む)
- [x] CONTRIBUTING スクリプトで tarball 差し込み scaffold → `pnpm install` → `pnpm dev` → Playwright でブラウザ実挙動確認:
  - [x] Clicker: 3 クリックで `<output>` が `\"3\"` に更新
  - [x] Desktop メニュー: ボタンクリックで `aria-expanded=true`、外側クリック / Escape で `false` に復帰
  - [x] Mobile メニュー (375×812): ボタンで `aria-expanded=true` + `html.overflow-hidden=true` + `inert=false`、Escape で全て逆に復帰 (body スクロール停止も解除)
- [x] コンソールエラー 0 (修正前は `Error: Cycle detected` × 3)

## bundle への影響
| bundle | before | after |
| :--- | ---: | ---: |
| clicker.client.js | 14,505 B | 1,294 B |
| desktop.client.js | 130,373 B | 116,522 B |
| mobile.client.js | 116,997 B | 103,153 B |

signals は bundle 内に bare specifier (\`from \"@preact/signals\"\`) として残り、import map 経由で esm.sh の共有インスタンスに解決される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)