### PR TITLE
fix(eleventy-plugin-preact-island): dist 未存在で is-land.js が出力ディレクトリ自体に書かれる不具合を修正

### DIFF
--- a/packages/eleventy-plugin-preact-island/index.js
+++ b/packages/eleventy-plugin-preact-island/index.js
@@ -143,9 +143,17 @@ export default function (eleventyConfig, pluginOptions = {}) {
     });
   }
 
-  // Copy is-land.js to output directory
+  // Copy is-land.js to output directory.
+  // NOTE: ターゲットは必ず出力ファイル名 (`/is-land.js`) を渡す。`"/"` を渡すと
+  // Eleventy の TemplatePassthrough.getOutputPath が末尾スラッシュを剥がして
+  // `<outputDir>` に潰し、その後の「dest がディレクトリなら dest/basename に書く」
+  // 分岐が dest の存在有無に依存する (recursive-copy に単一ファイル → 未存在パスを
+  // 渡すとリネームとして解釈される) ため、クリーンビルドでは `<outputDir>` 自体が
+  // is-land.js の中身を持つファイルに化ける。importmap 側 (`${urlPrefix}is-land.js`)
+  // と揃えて確定名にすることでこの罠を回避する。
   eleventyConfig.addPassthroughCopy({
-    [url.fileURLToPath(import.meta.resolve("@11ty/is-land/is-land.js"))]: "/",
+    [url.fileURLToPath(import.meta.resolve("@11ty/is-land/is-land.js"))]:
+      "/is-land.js",
   });
   const preactSuffix = resolvedPreactVersion ? `@${resolvedPreactVersion}` : "";
 

--- a/packages/eleventy-plugin-preact-island/index.test.js
+++ b/packages/eleventy-plugin-preact-island/index.test.js
@@ -25,11 +25,15 @@ function makeEleventyConfigStub({
   const eventHandlers = new Map();
   const ignoreAdds = [];
   const transforms = new Map();
+  const passthroughCopies = [];
   return {
     pathPrefix,
     directories: { input, output },
     versionCheck() {},
-    addPassthroughCopy() {},
+    addPassthroughCopy(arg) {
+      passthroughCopies.push(arg);
+    },
+    _passthroughCopies: passthroughCopies,
     addTransform(name, fn) {
       transforms.set(name, fn);
     },
@@ -220,5 +224,41 @@ describe("Island plugin ignore ルール (常時追加)", () => {
     assert.deepStrictEqual(config._ignoreAdds, [
       "./**/*.client.{js,jsx,ts,tsx}",
     ]);
+  });
+});
+
+describe("Island plugin is-land.js の passthrough copy ターゲット", () => {
+  // NOTE: ここは「dist の有無で書き出し結果が変わる」不具合の回帰テスト。
+  // ターゲットに "/" を渡すと Eleventy 側で末尾スラッシュが剥がれた結果
+  // クリーンビルド時に <outputDir> 自体がファイルに化ける。ターゲットは必ず
+  // 出力ファイル名を含む文字列 ("/is-land.js") でなければならない。
+  it("ターゲットが '/is-land.js' で addPassthroughCopy に登録される", () => {
+    const config = makeEleventyConfigStub();
+    preactIsland(config);
+
+    const entries = config._passthroughCopies.filter(
+      (arg) => arg && typeof arg === "object" && !Array.isArray(arg),
+    );
+    assert.strictEqual(entries.length, 1, "expected a single object-form copy");
+    const targets = Object.values(entries[0]);
+    assert.deepStrictEqual(targets, ["/is-land.js"]);
+    // NOTE: source 側は require.resolve('@11ty/is-land/is-land.js') に依存するため
+    // パス自体は絶対パスであることだけを確認する (プロジェクトによって値が変わる)。
+    const [source] = Object.keys(entries[0]);
+    assert.ok(
+      source.endsWith("/is-land.js"),
+      `unexpected source path: ${source}`,
+    );
+  });
+
+  it("bundle: false でも is-land.js の passthrough copy は登録される", () => {
+    const config = makeEleventyConfigStub();
+    preactIsland(config, { bundle: false });
+
+    const entries = config._passthroughCopies.filter(
+      (arg) => arg && typeof arg === "object" && !Array.isArray(arg),
+    );
+    assert.strictEqual(entries.length, 1);
+    assert.deepStrictEqual(Object.values(entries[0]), ["/is-land.js"]);
   });
 });

--- a/packages/eleventy-plugin-preact-island/index.test.js
+++ b/packages/eleventy-plugin-preact-island/index.test.js
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import path from "node:path";
 import { describe, it } from "node:test";
 import assert from "node:assert";
 import { h } from "preact";
@@ -242,13 +243,12 @@ describe("Island plugin is-land.js の passthrough copy ターゲット", () => 
     assert.strictEqual(entries.length, 1, "expected a single object-form copy");
     const targets = Object.values(entries[0]);
     assert.deepStrictEqual(targets, ["/is-land.js"]);
-    // NOTE: source 側は require.resolve('@11ty/is-land/is-land.js') に依存するため
-    // パス自体は絶対パスであることだけを確認する (プロジェクトによって値が変わる)。
+    // NOTE: source 側は import.meta.resolve('@11ty/is-land/is-land.js') を
+    // url.fileURLToPath したパス。実体は pnpm store 等のインストール先で
+    // プロジェクトごとに値が変わる。Windows では path.sep が '\' なので
+    // 末尾一致ではなく path.basename でファイル名だけを固定する。
     const [source] = Object.keys(entries[0]);
-    assert.ok(
-      source.endsWith("/is-land.js"),
-      `unexpected source path: ${source}`,
-    );
+    assert.strictEqual(path.basename(source), "is-land.js");
   });
 
   it("bundle: false でも is-land.js の passthrough copy は登録される", () => {


### PR DESCRIPTION
## Summary

- object 形式の `addPassthroughCopy` で is-land.js のターゲットを `"/"` から `"/is-land.js"` (確定ファイル名) に変更。Eleventy 3.x の `TemplatePassthrough.getOutputPath` は `"/"` を渡すと `TemplatePath.normalize` で末尾スラッシュが剥がれて出力ディレクトリ名 (例: `"dist"`) に潰れ、続く「dest がディレクトリなら dest/basename に書く」分岐が dest の存在有無に依存する。**その結果、`dist` が事前に存在しないクリーンビルドでは `@11ty/recursive-copy` が単一ファイル source を未存在パスへのリネームとして解釈し、`dist` 自体が is-land.js の中身を持つファイルに化けて他テンプレート出力を巻き添えにする** (Eleventy #2278 と同系統の落とし穴)。
- importmap 側 (`${urlPrefix}is-land.js`) と揃った確定名にすることで、この分岐に依存せず `<outputDir>/is-land.js` に固定できる。
- 回帰テストとして、`makeEleventyConfigStub` に `addPassthroughCopy` の引数記録を足し、`"/is-land.js"` を渡していることを bundle デフォルト / `bundle: false` の両ケースで検証するユニットテストを 2 本追加。

## Test plan

- [x] `pnpm --filter @tuqulore-inc/eleventy-plugin-preact-island test` (45 pass)
- [x] `pnpm --filter @tuqulore-inc/eleventy-plugin-preact-island lint`
- [x] 実 `@11ty/eleventy@3.1.6` を最小構成 (`src/index.html` + object 形式 `addPassthroughCopy({[isLand]: "/is-land.js"})`) で走らせて動作確認
  - 修正前 (target=`"/"`): `dist` 未存在からのクリーンビルドで `dist` が **ファイル** (is-land.js の中身, 12507B) に化ける
  - 修正後 (target=`"/is-land.js"`): `dist` 未存在でも `dist/is-land.js` + `dist/index.html` が正しく置かれる
  - `dist` が既存ディレクトリの場合はどちらでも正常 (期待通り)

🤖 Generated with [Claude Code](https://claude.com/claude-code)