### PR TITLE
Migrate docs site from Pages to Workers deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A monorepo of boilerplate code and tooling for building Eleventy projects.
 
 ## Documentation
 
-Full documentation lives at [website.tuqulore.pages.dev](https://website.tuqulore.pages.dev/).
+Full documentation lives at [website.tuqulore.workers.dev](https://website.tuqulore.workers.dev/).
 
 ## Packages
 

--- a/packages/docs/.env.production
+++ b/packages/docs/.env.production
@@ -1,1 +1,1 @@
-SITE_URL=https://website.tuqulore.pages.dev/
+SITE_URL=https://website.tuqulore.workers.dev/

--- a/packages/docs/wrangler.jsonc
+++ b/packages/docs/wrangler.jsonc
@@ -1,0 +1,9 @@
+{
+  // Cloudflare Workers (static assets) deployment config for the docs site.
+  // The Worker name determines the workers.dev URL: website.tuqulore.workers.dev
+  "name": "website",
+  "compatibility_date": "2026-07-13",
+  "assets": {
+    "directory": "./dist",
+  },
+}

--- a/packages/docs/wrangler.jsonc
+++ b/packages/docs/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
   // Cloudflare Workers (static assets) deployment config for the docs site.
-  // The Worker name determines the workers.dev URL: website.tuqulore.workers.dev
+  // workers.dev URL is: https://<name>.<account-subdomain>.workers.dev (e.g. https://website.tuqulore.workers.dev)
   "name": "website",
   "compatibility_date": "2026-07-13",
   "assets": {

--- a/packages/eleventy-plugin-postcss/README.md
+++ b/packages/eleventy-plugin-postcss/README.md
@@ -4,7 +4,7 @@ Eleventy plugin for processing CSS with PostCSS.
 
 ## Documentation
 
-The design rationale (why an independent plugin, `contentGlob` and Tailwind dependency tracking, applying Tailwind CSS) lives at [Plugins / eleventy-plugin-postcss](https://website.tuqulore.pages.dev/en/plugins/eleventy-plugin-postcss/).
+The design rationale (why an independent plugin, `contentGlob` and Tailwind dependency tracking, applying Tailwind CSS) lives at [Plugins / eleventy-plugin-postcss](https://website.tuqulore.workers.dev/en/plugins/eleventy-plugin-postcss/).
 
 ## Installation
 

--- a/packages/eleventy-plugin-preact-island/README.md
+++ b/packages/eleventy-plugin-preact-island/README.md
@@ -6,7 +6,7 @@ An Island is SSR-rendered HTML with client-side JavaScript layered on top; this 
 
 ## Documentation
 
-The design rationale (why Partial Hydration, why is-land, the `.client.*` convention, `<Island>` semantics, Island granularity) lives at [Plugins / eleventy-plugin-preact-island](https://website.tuqulore.pages.dev/en/plugins/eleventy-plugin-preact-island/).
+The design rationale (why Partial Hydration, why is-land, the `.client.*` convention, `<Island>` semantics, Island granularity) lives at [Plugins / eleventy-plugin-preact-island](https://website.tuqulore.workers.dev/en/plugins/eleventy-plugin-preact-island/).
 
 ## Installation
 

--- a/packages/eleventy-plugin-preact/README.md
+++ b/packages/eleventy-plugin-preact/README.md
@@ -6,7 +6,7 @@ This plugin registers `.jsx` and `.mdx` as Eleventy template formats and renders
 
 ## Documentation
 
-The design rationale (why Preact, why MDX, layout chaining) lives at [Plugins / eleventy-plugin-preact](https://website.tuqulore.pages.dev/en/plugins/eleventy-plugin-preact/). The writing conventions (`export const data`, `layout`, the `eleventy` singleton) live at [Preset Conventions](https://website.tuqulore.pages.dev/en/preset/).
+The design rationale (why Preact, why MDX, layout chaining) lives at [Plugins / eleventy-plugin-preact](https://website.tuqulore.workers.dev/en/plugins/eleventy-plugin-preact/). The writing conventions (`export const data`, `layout`, the `eleventy` singleton) live at [Preset Conventions](https://website.tuqulore.workers.dev/en/preset/).
 
 ## Installation
 
@@ -41,7 +41,7 @@ The Eleventy plugin factory. Register with `eleventyConfig.addPlugin(preact)`.
 
 ### `import { eleventy } from "@tuqulore-inc/eleventy-plugin-preact/eleventy"`
 
-The SSR-side singleton. Exposes `content`, `title`, `description`, `site`, `nav`, `page`, and any other data provided by Eleventy. Available only during SSR; not accessible from client-hydrated components. See [Preset Conventions / Data Access](https://website.tuqulore.pages.dev/en/preset/data-access/) for details.
+The SSR-side singleton. Exposes `content`, `title`, `description`, `site`, `nav`, `page`, and any other data provided by Eleventy. Available only during SSR; not accessible from client-hydrated components. See [Preset Conventions / Data Access](https://website.tuqulore.workers.dev/en/preset/data-access/) for details.
 
 ## Requirements
 

--- a/packages/eleventy-preset/README.md
+++ b/packages/eleventy-preset/README.md
@@ -4,11 +4,11 @@ Eleventy preset for building static sites with Preact JSX/MDX templates, Partial
 
 ## Documentation
 
-Design rationale, day-to-day writing conventions, and applied recipes live at [website.tuqulore.pages.dev](https://website.tuqulore.pages.dev/). See especially:
+Design rationale, day-to-day writing conventions, and applied recipes live at [website.tuqulore.workers.dev](https://website.tuqulore.workers.dev/). See especially:
 
-- [Architecture](https://website.tuqulore.pages.dev/en/architecture/) — the overall design and key trade-offs.
-- [Preset Conventions](https://website.tuqulore.pages.dev/en/preset/) — writing conventions (directory layout, templates, data access).
-- [Plugins](https://website.tuqulore.pages.dev/en/plugins/) — internal design of the plugins this preset bundles.
+- [Architecture](https://website.tuqulore.workers.dev/en/architecture/) — the overall design and key trade-offs.
+- [Preset Conventions](https://website.tuqulore.workers.dev/en/preset/) — writing conventions (directory layout, templates, data access).
+- [Plugins](https://website.tuqulore.workers.dev/en/plugins/) — internal design of the plugins this preset bundles.
 
 ## Installation
 
@@ -78,11 +78,11 @@ Returns an Eleventy configuration function that registers the three plugins abov
 
 ### `import { eleventy } from "@tuqulore-inc/eleventy-preset/eleventy"`
 
-Re-exports the SSR-side singleton from [@tuqulore-inc/eleventy-plugin-preact](../eleventy-plugin-preact) for reading page data and global data without prop drilling. See [Preset Conventions / Data Access](https://website.tuqulore.pages.dev/en/preset/data-access/) for the shape and usage.
+Re-exports the SSR-side singleton from [@tuqulore-inc/eleventy-plugin-preact](../eleventy-plugin-preact) for reading page data and global data without prop drilling. See [Preset Conventions / Data Access](https://website.tuqulore.workers.dev/en/preset/data-access/) for the shape and usage.
 
 ### `import { Island, clientComponent } from "@tuqulore-inc/eleventy-preset/island"`
 
-Re-exports from [@tuqulore-inc/eleventy-plugin-preact-island](../eleventy-plugin-preact-island) for authoring Partial Hydration. See [Plugins / eleventy-plugin-preact-island](https://website.tuqulore.pages.dev/en/plugins/eleventy-plugin-preact-island/) for the design and that package's README for the full API.
+Re-exports from [@tuqulore-inc/eleventy-plugin-preact-island](../eleventy-plugin-preact-island) for authoring Partial Hydration. See [Plugins / eleventy-plugin-preact-island](https://website.tuqulore.workers.dev/en/plugins/eleventy-plugin-preact-island/) for the design and that package's README for the full API.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
Migrates the documentation site deployment from Cloudflare Pages to Cloudflare Workers, updating all references and adding the necessary Workers configuration.

## Key Changes
- Updated all documentation URLs from `website.tuqulore.pages.dev` to `website.tuqulore.workers.dev` across multiple README files and environment configuration
- Added `packages/docs/wrangler.jsonc` configuration file for Cloudflare Workers static assets deployment
- Updated production environment variable `SITE_URL` to reflect the new Workers deployment domain

## Files Modified
- **README files**: Updated documentation links in root README and package-specific READMEs (eleventy-preset, eleventy-plugin-preact, eleventy-plugin-postcss, eleventy-plugin-preact-island)
- **Environment config**: Updated `.env.production` with new site URL
- **Workers config**: Added new `wrangler.jsonc` with static assets configuration pointing to the `./dist` directory

## Implementation Details
The Workers configuration uses the standard Cloudflare Workers setup for serving static assets, with the Worker name "website" determining the `workers.dev` subdomain URL.

https://claude.ai/code/session_01YKyTWAwn4P8pJ2Zw1Wgt7w