### PR TITLE
ci: リリース系ワークフローの bump PR に release ラベルを付与する

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: tuqulore/.github/setup@11aae4eb6384c34e47e7ab530576d416ec9ff007 # main
+      - uses: tuqulore/.github/setup@8caf5d569132d10bb856f4c14b2530c0e9e8f1ba # main
       - run: pnpm lint
       - run: pnpm -r test
-      - uses: tuqulore/.github/format@11aae4eb6384c34e47e7ab530576d416ec9ff007 # main
+      - uses: tuqulore/.github/format@8caf5d569132d10bb856f4c14b2530c0e9e8f1ba # main

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -104,6 +104,17 @@ jobs:
           pr-body: Bump to alpha version v${VERSION}
           github-token: ${{ github.token }}
 
+      - name: Add release label to alpha PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=$(gh pr list --base main --head alpha --json number --jq '.[0].number // empty')
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr edit "$PR_NUMBER" --add-label release || echo "::warning::Failed to add release label to PR #${PR_NUMBER}"
+          else
+            echo "::warning::Could not find alpha PR to label"
+          fi
+
       - name: Cleanup alpha branch on failure or cancellation
         if: failure() || cancelled()
         run: git push origin :alpha || true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -102,18 +102,8 @@ jobs:
           commit-prefix: chore(alpha)
           pr-base: main
           pr-body: Bump to alpha version v${VERSION}
+          pr-label: release
           github-token: ${{ github.token }}
-
-      - name: Add release label to alpha PR
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          PR_NUMBER=$(gh pr list --base main --head alpha --json number --jq '.[0].number // empty')
-          if [ -n "$PR_NUMBER" ]; then
-            gh pr edit "$PR_NUMBER" --add-label release || echo "::warning::Failed to add release label to PR #${PR_NUMBER}"
-          else
-            echo "::warning::Could not find alpha PR to label"
-          fi
 
       - name: Cleanup alpha branch on failure or cancellation
         if: failure() || cancelled()

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: tuqulore/.github/resolve-target-sha@11aae4eb6384c34e47e7ab530576d416ec9ff007 # main
+      - uses: tuqulore/.github/resolve-target-sha@8caf5d569132d10bb856f4c14b2530c0e9e8f1ba # main
         id: target
         with:
           default-branch: main
@@ -58,11 +58,11 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
-      - uses: tuqulore/.github/setup@11aae4eb6384c34e47e7ab530576d416ec9ff007 # main
+      - uses: tuqulore/.github/setup@8caf5d569132d10bb856f4c14b2530c0e9e8f1ba # main
         with:
           fetch-depth: 0
 
-      - uses: tuqulore/.github/configure-git@11aae4eb6384c34e47e7ab530576d416ec9ff007 # main
+      - uses: tuqulore/.github/configure-git@8caf5d569132d10bb856f4c14b2530c0e9e8f1ba # main
 
       # 公開物とタグの指すコミットを一致させるため、check で解決した SHA を detached HEAD で checkout する。
       - name: Checkout target sha for publishing
@@ -94,7 +94,7 @@ jobs:
         run: |
           git checkout -B main origin/main
 
-      - uses: tuqulore/.github/bump-and-pr@11aae4eb6384c34e47e7ab530576d416ec9ff007 # main
+      - uses: tuqulore/.github/bump-and-pr@8caf5d569132d10bb856f4c14b2530c0e9e8f1ba # main
         with:
           branch: alpha
           bump-command: pnpm packages:bump-version prerelease --preid alpha --yes --no-git-tag-version

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -102,7 +102,7 @@ jobs:
           commit-prefix: chore(alpha)
           pr-base: main
           pr-body: Bump to alpha version v${VERSION}
-          pr-label: release
+          pr-labels: release
           github-token: ${{ github.token }}
 
       - name: Cleanup alpha branch on failure or cancellation

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,18 +64,8 @@ jobs:
             jq --arg version "^$VERSION" '.devDependencies["@tuqulore-inc/eleventy-preset"] = $version' \
               packages/create-eleventy/templates/default/package.json > tmp.json
             mv tmp.json packages/create-eleventy/templates/default/package.json
+          pr-label: release
           github-token: ${{ github.token }}
-
-      - name: Add release label to PR
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          PR_NUMBER=$(gh pr list --base main --head release --json number --jq '.[0].number // empty')
-          if [ -n "$PR_NUMBER" ]; then
-            gh pr edit "$PR_NUMBER" --add-label release || echo "::warning::Failed to add release label to PR #${PR_NUMBER}"
-          else
-            echo "::warning::Could not find release PR to label"
-          fi
 
       - name: Cleanup on failure or cancellation
         if: failure() || cancelled()

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,6 +66,17 @@ jobs:
             mv tmp.json packages/create-eleventy/templates/default/package.json
           github-token: ${{ github.token }}
 
+      - name: Add release label to PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=$(gh pr list --base main --head release --json number --jq '.[0].number // empty')
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr edit "$PR_NUMBER" --add-label release || echo "::warning::Failed to add release label to PR #${PR_NUMBER}"
+          else
+            echo "::warning::Could not find release PR to label"
+          fi
+
       - name: Cleanup on failure or cancellation
         if: failure() || cancelled()
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,11 +23,11 @@ jobs:
   release:
     runs-on: ubuntu-24.04
     steps:
-      - uses: tuqulore/.github/setup@11aae4eb6384c34e47e7ab530576d416ec9ff007 # main
+      - uses: tuqulore/.github/setup@8caf5d569132d10bb856f4c14b2530c0e9e8f1ba # main
         with:
           fetch-depth: 0
 
-      - uses: tuqulore/.github/configure-git@11aae4eb6384c34e47e7ab530576d416ec9ff007 # main
+      - uses: tuqulore/.github/configure-git@8caf5d569132d10bb856f4c14b2530c0e9e8f1ba # main
 
       - name: Find previous release tag
         id: previous-tag
@@ -47,7 +47,7 @@ jobs:
           fi
           echo "url=${URL}" >> "$GITHUB_OUTPUT"
 
-      - uses: tuqulore/.github/bump-and-pr@11aae4eb6384c34e47e7ab530576d416ec9ff007 # main
+      - uses: tuqulore/.github/bump-and-pr@8caf5d569132d10bb856f4c14b2530c0e9e8f1ba # main
         with:
           branch: release
           bump-command: pnpm packages:bump-version ${{ inputs.semver }} --yes --no-git-tag-version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
             jq --arg version "^$VERSION" '.devDependencies["@tuqulore-inc/eleventy-preset"] = $version' \
               packages/create-eleventy/templates/default/package.json > tmp.json
             mv tmp.json packages/create-eleventy/templates/default/package.json
-          pr-label: release
+          pr-labels: release
           github-token: ${{ github.token }}
 
       - name: Cleanup on failure or cancellation


### PR DESCRIPTION
## 概要

リリース系ワークフロー (`release` / `publish`) が `bump-and-pr` で作成するバージョン更新 PR に、`release` ラベルが付与されるようにします。

## 背景

`.github/release.yaml`(自動生成リリースノートの設定)は、`release` ラベルの付いた PR を changelog から**除外**する設定になっています。

```yaml
changelog:
  exclude:
    labels:
      - release
```

しかし、これまで各ワークフローが作成する bump PR には `release` ラベルが一切付与されておらず、`chore(release):` / `chore(alpha):` といったバージョン更新 PR が自動生成リリースノートに混入していました。

## 変更内容

`bump-and-pr` composite action に追加された `pr-label` オプションを使い、作成される PR に `release` ラベルを付与します。

| ワークフロー | 対象 PR | 付与ラベル |
|---|---|---|
| `release.yaml` | リリース PR (`chore(release):`) | `release` |
| `publish.yaml` | alpha bump PR (`chore(alpha):`) | `release` |

これにより、バージョン更新 PR が自動生成リリースノートに含まれなくなります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wD9tmAjL37kqNsTJswjm2

---
_Generated by [Claude Code](https://claude.ai/code/session_017wD9tmAjL37kqNsTJswjm2)_