### PR TITLE
fix(create-eleventy): default テンプレートの Island 発火条件を on="visible" に変更する

### DIFF
--- a/packages/create-eleventy/templates/default/README.md
+++ b/packages/create-eleventy/templates/default/README.md
@@ -134,14 +134,14 @@ export default clientComponent(Counter, import.meta.url);
 import { Island } from "@tuqulore-inc/eleventy-preset/island";
 import Counter from "./counter.client.jsx";
 
-<Island component={Counter} on="interaction" initial={5} />
+<Island component={Counter} on="visible" initial={5} />
 ```
 
 For the example above, `<Island>` emits an `<is-land>` element like this from SSR:
 
 ```html
 <is-land
-  land-on:interaction
+  land-on:visible
   type="preact"
   import="/counter.client.js"
   props='{"initial":5}'

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header.mdx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header.mdx
@@ -10,13 +10,13 @@ import Mobile from "./header/mobile.client.jsx";
     </a>
     <Island
       component={Desktop}
-      on="interaction"
+      on="visible"
       class="hidden md:block"
       nav={eleventy.nav}
     />
     <Island
       component={Mobile}
-      on="interaction"
+      on="visible"
       class="ml-auto flex items-center md:hidden"
       nav={eleventy.nav}
     />

--- a/packages/create-eleventy/templates/default/src/index.mdx
+++ b/packages/create-eleventy/templates/default/src/index.mdx
@@ -19,6 +19,6 @@ import Clicker from "./clicker.client.jsx";
 
 ## Partial Hydration サンプル
 
-以下のカウンターは Preact コンポーネントで、初回操作時にクライアント側でハイドレーションされます。
+以下のカウンターは Preact コンポーネントで、表示領域に入ったタイミングでクライアント側でハイドレーションされます。
 
-<Island component={Clicker} on="interaction" />
+<Island component={Clicker} on="visible" />


### PR DESCRIPTION
## Summary

- default テンプレートの `<Island>` 3 箇所 (Desktop / Mobile ナビゲーション、Clicker デモ) の発火条件を `on="interaction"` から `on="visible"` に変更
- `on="interaction"` は最初の click / touchstart で hydration をトリガーするが、is-land の `Conditions.interaction` は元イベントを再ディスパッチしないため、Preact の `onClick` が反応するのは 2 回目のクリックから。ヘッダーのドロップダウンやハンバーガーが「1 回押しても開かない」不具合の原因
- 対象 3 箇所はすべて初期 viewport 内にあり、`on="visible"` でも実質即時 hydrate される。ページ下方の Island に対する遅延ロード効果は温存
- Clicker の説明文も新しい発火条件に合わせて「初回操作時に」→「表示領域に入ったタイミングで」に更新
- default テンプレート同梱の README サンプル (`packages/create-eleventy/templates/default/README.md`) の Counter 例も `on="visible"` / `land-on:visible` に揃え、scaffold 直後の利用者が同じ罠を踏まないようにした

## Test plan

- [x] `pnpm --filter @tuqulore-inc/create-eleventy lint`
- [x] `pnpm --filter @tuqulore-inc/create-eleventy test` (scaffold + `pnpm build` の 7 tests all pass)
- [x] Prettier `--check` OK
- [ ] scaffold したプロジェクトを `pnpm start` で立ち上げ、以下を目視確認:
  - [ ] ヘッダーのドロップダウンが 1 クリックで開く (Desktop)
  - [ ] ハンバーガーメニューが 1 タップで開く (Mobile)
  - [ ] Clicker が表示後の 1 回目のクリックでカウントアップする (hydration 済みなので 1 クリックで反応)

## Notes / スコープ外

- プラグイン `Island` 側の default `on` (`packages/eleventy-plugin-preact-island/island.js:58`) はいまも `"interaction"` のまま。default に依存している他コードは今後も同じ罠を踏むので、default 変更や「即時 hydrate」用の値追加は別 PR で検討したい
- `packages/docs/` 内の MDX サンプルにも `on="interaction"` の記述があるが、default テンプレート外なので本 PR では触っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)