### PR TITLE
fix(create-eleventy): jsx-a11y / react lint error at default template

### DIFF
--- a/packages/create-eleventy/templates/default/package.json
+++ b/packages/create-eleventy/templates/default/package.json
@@ -29,7 +29,6 @@
     "postcss": "^8.5.6",
     "preact": "^10.26.4",
     "shx": "^0.4.0",
-    "slugify": "^1.6.6",
     "tailwind-merge": "^3.0.2",
     "tailwindcss": "^4.1.18"
   },

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
@@ -1,7 +1,6 @@
 import { useSignal, useSignalEffect } from "@preact/signals";
 import { clientComponent } from "@tuqulore-inc/eleventy-preset/island";
-import { useRef } from "preact/hooks";
-import slugify from "slugify";
+import { useId, useRef } from "preact/hooks";
 import { twMerge } from "tailwind-merge";
 
 function MenuList(props) {
@@ -15,7 +14,7 @@ function MenuList(props) {
   };
   const ref = useRef(null);
   const buttonRef = useRef(null);
-  const slug = slugify(props.item.name);
+  const slug = useId();
   useSignalEffect(() => {
     if (!open.value) return;
     const clickHandler = (e) => {

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
@@ -15,7 +15,7 @@ function MenuList(props) {
   };
   const ref = useRef(null);
   const buttonRef = useRef(null);
-  const slug = `${slugify(props.item.name)}-${props.index}`;
+  const slug = slugify(props.item.name);
   useSignalEffect(() => {
     if (!open.value) return;
     const clickHandler = (e) => {
@@ -76,12 +76,12 @@ function Desktop(props) {
   return (
     <nav class={props.class}>
       <ul class="flex items-center">
-        {props.nav.map((item, itemIndex) =>
+        {props.nav.map((item) =>
           "children" in item ? (
-            <li key={`${item.name}-${itemIndex}`} class="relative">
-              <MenuList item={item} index={itemIndex}>
-                {item.children.map((child, childIndex) => (
-                  <li key={`${child.name}-${childIndex}`}>
+            <li key={item.name} class="relative">
+              <MenuList item={item}>
+                {item.children.map((child) => (
+                  <li key={child.name}>
                     <a class="jumpu-text-button w-full whitespace-nowrap" href={child.path}>
                       {child.name}
                     </a>
@@ -90,7 +90,7 @@ function Desktop(props) {
               </MenuList>
             </li>
           ) : (
-            <li key={`${item.name}-${itemIndex}`}>
+            <li key={item.name}>
               <a class="jumpu-text-button" href={item.path}>
                 {item.name}
               </a>

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/desktop.client.jsx
@@ -14,7 +14,7 @@ function MenuList(props) {
   };
   const ref = useRef(null);
   const buttonRef = useRef(null);
-  const slug = useId();
+  const baseId = useId();
   useSignalEffect(() => {
     if (!open.value) return;
     const clickHandler = (e) => {
@@ -43,9 +43,9 @@ function MenuList(props) {
       }}
     >
       <button
-        id={`nav-button-${slug}`}
+        id={`nav-button-${baseId}`}
         ref={buttonRef}
-        aria-controls={`nav-menu-${slug}`}
+        aria-controls={`nav-menu-${baseId}`}
         aria-expanded={open.value}
         class="jumpu-text-button"
         type="button"
@@ -54,8 +54,8 @@ function MenuList(props) {
         {props.item.name}
       </button>
       <ul
-        id={`nav-menu-${slug}`}
-        aria-labelledby={`nav-button-${slug}`}
+        id={`nav-menu-${baseId}`}
+        aria-labelledby={`nav-button-${baseId}`}
         class={twMerge(
           "jumpu-card absolute top-full left-1/2 max-h-[50vh] -translate-x-1/2 overflow-y-auto p-2",
           "translate-y-2 transition duration-75 ease-in-out",

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
@@ -61,16 +61,16 @@ function Mobile(props) {
           <span class="icon-[material-symbols--close]"></span>
         </button>
         <ul class="flex flex-col px-4 py-16">
-          {props.nav.map((item, itemIndex) => (
-            <li key={`${item.name}-${itemIndex}`}>
+          {props.nav.map((item) => (
+            <li key={item.name}>
               {item.children && (
-                <div class="mb-6" role="group" aria-label={item.name}>
-                  <p class="mb-2 ml-4 text-lg" aria-hidden="true">
+                <div class="mb-6">
+                  <p id={`nav-mobile-group-${item.name}`} class="mb-2 ml-4 text-lg">
                     {item.name}
                   </p>
-                  <ul>
-                    {item.children.map((child, childIndex) => (
-                      <li key={`${child.name}-${childIndex}`}>
+                  <ul aria-labelledby={`nav-mobile-group-${item.name}`}>
+                    {item.children.map((child) => (
+                      <li key={child.name}>
                         <a class="jumpu-text-button block" href={child.path}>
                           {child.name}
                         </a>

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
@@ -1,8 +1,27 @@
 import { useSignal, useSignalEffect } from "@preact/signals";
 import { clientComponent } from "@tuqulore-inc/eleventy-preset/island";
-import { useRef } from "preact/hooks";
-import slugify from "slugify";
+import { useId, useRef } from "preact/hooks";
 import { twMerge } from "tailwind-merge";
+
+function NavGroup(props) {
+  const groupId = useId();
+  return (
+    <div class="mb-6">
+      <p id={groupId} class="mb-2 ml-4 text-lg">
+        {props.item.name}
+      </p>
+      <ul aria-labelledby={groupId}>
+        {props.item.children.map((child) => (
+          <li key={child.name}>
+            <a class="jumpu-text-button block" href={child.path}>
+              {child.name}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
 
 function Mobile(props) {
   const open = useSignal(false);
@@ -62,34 +81,16 @@ function Mobile(props) {
           <span class="icon-[material-symbols--close]"></span>
         </button>
         <ul class="flex flex-col px-4 py-16">
-          {props.nav.map((item) => {
-            const groupId = `nav-mobile-group-${slugify(item.name)}`;
-            return (
-              <li key={item.name}>
-                {item.children && (
-                  <div class="mb-6">
-                    <p id={groupId} class="mb-2 ml-4 text-lg">
-                      {item.name}
-                    </p>
-                    <ul aria-labelledby={groupId}>
-                      {item.children.map((child) => (
-                        <li key={child.name}>
-                          <a class="jumpu-text-button block" href={child.path}>
-                            {child.name}
-                          </a>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-                {item.path && (
-                  <a class="jumpu-text-button block" href={item.path}>
-                    {item.name}
-                  </a>
-                )}
-              </li>
-            );
-          })}
+          {props.nav.map((item) => (
+            <li key={item.name}>
+              {item.children && <NavGroup item={item} />}
+              {item.path && (
+                <a class="jumpu-text-button block" href={item.path}>
+                  {item.name}
+                </a>
+              )}
+            </li>
+          ))}
         </ul>
       </nav>
     </div>

--- a/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
+++ b/packages/create-eleventy/templates/default/src/__includes/partials/header/mobile.client.jsx
@@ -1,6 +1,7 @@
 import { useSignal, useSignalEffect } from "@preact/signals";
 import { clientComponent } from "@tuqulore-inc/eleventy-preset/island";
 import { useRef } from "preact/hooks";
+import slugify from "slugify";
 import { twMerge } from "tailwind-merge";
 
 function Mobile(props) {
@@ -61,31 +62,34 @@ function Mobile(props) {
           <span class="icon-[material-symbols--close]"></span>
         </button>
         <ul class="flex flex-col px-4 py-16">
-          {props.nav.map((item) => (
-            <li key={item.name}>
-              {item.children && (
-                <div class="mb-6">
-                  <p id={`nav-mobile-group-${item.name}`} class="mb-2 ml-4 text-lg">
+          {props.nav.map((item) => {
+            const groupId = `nav-mobile-group-${slugify(item.name)}`;
+            return (
+              <li key={item.name}>
+                {item.children && (
+                  <div class="mb-6">
+                    <p id={groupId} class="mb-2 ml-4 text-lg">
+                      {item.name}
+                    </p>
+                    <ul aria-labelledby={groupId}>
+                      {item.children.map((child) => (
+                        <li key={child.name}>
+                          <a class="jumpu-text-button block" href={child.path}>
+                            {child.name}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {item.path && (
+                  <a class="jumpu-text-button block" href={item.path}>
                     {item.name}
-                  </p>
-                  <ul aria-labelledby={`nav-mobile-group-${item.name}`}>
-                    {item.children.map((child) => (
-                      <li key={child.name}>
-                        <a class="jumpu-text-button block" href={child.path}>
-                          {child.name}
-                        </a>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              {item.path && (
-                <a class="jumpu-text-button block" href={item.path}>
-                  {item.name}
-                </a>
-              )}
-            </li>
-          ))}
+                  </a>
+                )}
+              </li>
+            );
+          })}
         </ul>
       </nav>
     </div>


### PR DESCRIPTION
## Summary
- PR #929 で導入した Oxlint (react / jsx-a11y plugin 有効) 環境で scaffold した際、default テンプレートの header 部品で error 1 件と warning 6 件が出ていた
- scaffold 直後のプロジェクトが `pnpm lint` で error になるのはユーザ体験として悪いため、テンプレコード側で解消する

## 解消した lint findings

**error (jsx-a11y)**

- `mobile.client.jsx:67` `jsx-a11y(prefer-tag-over-role)`: `role="group"` は semantic tag に置き換えるべき

**warning (react)**

- `desktop.client.jsx:81,84,93` / `mobile.client.jsx:65,73` `react(no-array-index-key)`: `.map((item, i) => <li key={\`${item.name}-${i}\`}>)` の配列 index 混入

## 変更内容

- **mobile.client.jsx**: `role="group"` + `aria-label` + `aria-hidden` のラッパを撤去し、visible な `<p id>` と `<ul aria-labelledby>` の関係に置き換え。sighted users と screen reader users が同じ heading を参照でき、`aria-hidden` で見出しを screen reader から隠していた不整合も解消
- **desktop / mobile 各所**: `key={\`${item.name}-${itemIndex}\`}` → `key={item.name}` に。nav item は name が一意である前提 (通常のヘッダ nav では自然な仮定)
- **desktop の MenuList**: `index` prop を廃止し、slug は `slugify(item.name)` のみに簡素化 (キーと同じく名前一意前提で一貫)

## Test plan
- [x] 現ブランチのソースを `pnpm.overrides` で差し込んだ scaffold で `pnpm lint` が exit 0
- [x] scaffold 側で `oxfmt --check` (21 files) と `pnpm build` (2 files 生成) が pass
- [x] monorepo 側の `pnpm -r lint` / `oxfmt --check` (133 files) / `pnpm --filter @tuqulore-inc/create-eleventy test` (7 tests) が pass
- [x] CI 全緑
- [x] scaffold 直後で `pnpm dev` した際、モバイル/デスクトップともにヘッダのナビゲーション操作 (menu 開閉、submenu 遷移、キーボード操作、focus 管理) が従来通り動く

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mwq93B2YncaafwT9iYwxu